### PR TITLE
docker api enforces tls from docker 1.13 onwards

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -52,7 +52,13 @@ func NewPool(endpoint string) (*Pool, error) {
 		}
 	}
 
-	client, err := dc.NewClient(endpoint)
+	// docker machine cert path, not sure how it applies to non-docker machine scenarios
+	path := os.Getenv("DOCKER_CERT_PATH")
+	ca :=  fmt.Sprintf("%s/ca.pem", path)
+	cert := fmt.Sprintf("%s/cert.pem", path)
+	key := fmt.Sprintf("%s/key.pem", path)
+
+	client, err := dc.NewTLSClient(endpoint, cert, key, ca)
 	if err != nil {
 		return nil, errors.Wrap(err, "")
 	}

--- a/dockertest.go
+++ b/dockertest.go
@@ -69,7 +69,7 @@ func NewPool(endpoint string) (*Pool, error) {
 		}
 	}
 	
-	client, err := dc.NewClient(endpoint, cert, key, ca)
+	client, err := dc.NewClient(endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "")
 	}


### PR DESCRIPTION
For docker 1.13 onwards, not using `dc.NewTLSClient` will fail with malformed http response.

Also, is there an option in dockertest v3 to support docker-machine? There was an option to support docker-machine in v2 but I can't seem to find it in v3. Providing such an option will allow us to use `dc.NewClientFromEnv()`.