### PR TITLE
Add ExposedPorts to RunOptions

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -92,12 +92,13 @@ func NewPool(endpoint string) (*Pool, error) {
 
 // RunOptions is used to pass in optional parameters when running a container.
 type RunOptions struct {
-	Repository string
-	Tag        string
-	Env        []string
-	Cmd        []string
-	Mounts     []string
-	Links      []string
+	Repository   string
+	Tag          string
+	Env          []string
+	Cmd          []string
+	Mounts       []string
+	Links        []string
+	ExposedPorts []string
 }
 
 // RunWithOptions starts a docker container.
@@ -108,6 +109,14 @@ func (d *Pool) RunWithOptions(opts *RunOptions) (*Resource, error) {
 	tag := opts.Tag
 	env := opts.Env
 	cmd := opts.Cmd
+	var exp map[dc.Port]struct{}
+
+	if len(opts.ExposedPorts) > 0 {
+		exp = map[dc.Port]struct{}{}
+		for _, p := range opts.ExposedPorts {
+			exp[dc.Port(p)] = struct{}{}
+		}
+	}
 
 	mounts := []dc.Mount{}
 
@@ -140,10 +149,11 @@ func (d *Pool) RunWithOptions(opts *RunOptions) (*Resource, error) {
 
 	c, err := d.Client.CreateContainer(dc.CreateContainerOptions{
 		Config: &dc.Config{
-			Image:  fmt.Sprintf("%s:%s", repository, tag),
-			Env:    env,
-			Cmd:    cmd,
-			Mounts: mounts,
+			Image:        fmt.Sprintf("%s:%s", repository, tag),
+			Env:          env,
+			Cmd:          cmd,
+			Mounts:       mounts,
+			ExposedPorts: exp,
 		},
 		HostConfig: &dc.HostConfig{
 			PublishAllPorts: true,

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -62,11 +62,13 @@ func TestMongo(t *testing.T) {
 	options := &RunOptions{
 		Repository: "mongo",
 		Tag:        "3.3.12",
-		Cmd:        []string{"mongod", "--smallfiles"},
+		Cmd:        []string{"mongod", "--smallfiles", "--port", "3000"},
+		// expose a different port
+		ExposedPorts: []string{"3000"},
 	}
 	resource, err := pool.RunWithOptions(options)
 	require.Nil(t, err)
-	port := resource.GetPort("27017/tcp")
+	port := resource.GetPort("3000/tcp")
 	assert.NotEmpty(t, port)
 
 	err = pool.Retry(func() error {


### PR DESCRIPTION
To handle using docker containers that didn't explicitly expose the port you want to use (or where you override the port) you need to modify the ports being exposed.

This one isn't a straight mapping unless you would prefer I expose the docker client types in your API.  Let me know your thoughts on the best way to handle it if you don't like this one.