### PR TITLE
Expose ability to set docker auth for private repos

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -100,6 +100,7 @@ type RunOptions struct {
 	Mounts       []string
 	Links        []string
 	ExposedPorts []string
+	Auth         dc.AuthConfiguration
 }
 
 // RunWithOptions starts a docker container.
@@ -144,7 +145,7 @@ func (d *Pool) RunWithOptions(opts *RunOptions) (*Resource, error) {
 		if err := d.Client.PullImage(dc.PullImageOptions{
 			Repository: repository,
 			Tag:        tag,
-		}, dc.AuthConfiguration{}); err != nil {
+		}, opts.Auth); err != nil {
 			return nil, errors.Wrap(err, "")
 		}
 	}


### PR DESCRIPTION
This takes the auth configuration off of the opts instead of just passing an empty one to `PullImage`, this way, users and set their own auth if necessary for the pull.

We mostly use a private registry, so annoying to have to pull locally manually first all the time.