### PR TITLE
Adds portbinding to RunWithOptions

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -130,6 +130,7 @@ type RunOptions struct {
 	Links        []string
 	ExposedPorts []string
 	Auth         dc.AuthConfiguration
+	PortBindings map[dc.Port][]dc.PortBinding
 }
 
 // RunWithOptions starts a docker container.
@@ -194,6 +195,7 @@ func (d *Pool) RunWithOptions(opts *RunOptions) (*Resource, error) {
 			PublishAllPorts: true,
 			Binds:           opts.Mounts,
 			Links:           opts.Links,
+			PortBindings:    opts.PortBindings,
 		},
 	})
 	if err != nil {

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	dc "github.com/fsouza/go-dockerclient"
 )
 
 var docker = os.Getenv("DOCKER_URL")
@@ -82,6 +83,21 @@ func TestContainerWithName(t *testing.T) {
 		})
 	require.Nil(t, err)
 	assert.Equal(t,"/db", resource.Container.Name)
+
+	require.Nil(t, pool.Purge(resource))
+}
+
+func TestContainerWithPortBinding(t *testing.T) {
+	resource, err := pool.RunWithOptions(
+		&RunOptions{
+			Repository: "postgres",
+			Tag: "9.5",
+			PortBindings: map[dc.Port][]dc.PortBinding{
+				"5432/tcp": {{HostIP: "", HostPort: "5433"}},
+			},
+		})
+	require.Nil(t, err)
+	assert.Equal(t,"5433", resource.GetPort("5432/tcp"))
 
 	require.Nil(t, pool.Purge(resource))
 }


### PR DESCRIPTION
Adds the ability to optionally specify a `port binding` for the container