### PR TITLE
Add method to build and run an image

### DIFF
--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -3,15 +3,16 @@ package dockertest
 import (
 	"database/sql"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"testing"
 
+	dc "github.com/fsouza/go-dockerclient"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	dc "github.com/fsouza/go-dockerclient"
 )
 
 var docker = os.Getenv("DOCKER_URL")
@@ -77,12 +78,12 @@ func TestMongo(t *testing.T) {
 func TestContainerWithName(t *testing.T) {
 	resource, err := pool.RunWithOptions(
 		&RunOptions{
-			Name: "db",
+			Name:       "db",
 			Repository: "postgres",
-			Tag: "9.5",
+			Tag:        "9.5",
 		})
 	require.Nil(t, err)
-	assert.Equal(t,"/db", resource.Container.Name)
+	assert.Equal(t, "/db", resource.Container.Name)
 
 	require.Nil(t, pool.Purge(resource))
 }
@@ -91,13 +92,31 @@ func TestContainerWithPortBinding(t *testing.T) {
 	resource, err := pool.RunWithOptions(
 		&RunOptions{
 			Repository: "postgres",
-			Tag: "9.5",
+			Tag:        "9.5",
 			PortBindings: map[dc.Port][]dc.PortBinding{
 				"5432/tcp": {{HostIP: "", HostPort: "5433"}},
 			},
 		})
 	require.Nil(t, err)
-	assert.Equal(t,"5433", resource.GetPort("5432/tcp"))
+	assert.Equal(t, "5433", resource.GetPort("5432/tcp"))
 
+	require.Nil(t, pool.Purge(resource))
+}
+
+func TestBuildImage(t *testing.T) {
+	// Create Dockerfile in temp dir
+	dir, _ := ioutil.TempDir("", "dockertest")
+	defer os.RemoveAll(dir)
+
+	dockerfilePath := dir + "/Dockerfile"
+	ioutil.WriteFile(dockerfilePath,
+		[]byte("FROM postgres:9.5"),
+		0644,
+	)
+
+	resource, err := pool.BuildAndRun("postgres-test", dockerfilePath, nil)
+	require.Nil(t, err)
+
+	assert.Equal(t, "/postgres-test", resource.Container.Name)
 	require.Nil(t, pool.Purge(resource))
 }

--- a/examples/BuildDockerfile.md
+++ b/examples/BuildDockerfile.md
@@ -1,0 +1,34 @@
+`./db/image/Dockerfile`
+```Dockerfile
+FROM postgres:latest
+
+# Add your customizations here
+```
+
+`./db_test.go`
+```go
+pool, err := dockertest.NewPool("")
+if err != nil {
+	log.Fatalf("Could not connect to docker: %s", err)
+}
+
+// Build and run the given Dockerfile
+resource, err := pool.BuildAndRun("my-postgres-test-image", "./db/image/Dockerfile", []string{})
+if err != nil {
+	log.Fatalf("Could not start resource: %s", err)
+}
+
+if err = pool.Retry(func() error {
+    var err error
+    db, err = sql.Open("postgres", fmt.Sprintf("postgres://postgres:secret@localhost:%s/%s?sslmode=disable", resource.GetPort("5432/tcp"), database))
+    if err != nil {
+        return err
+    }
+    return db.Ping()
+}); err != nil {
+    log.Fatalf("Could not connect to docker: %s", err)
+}
+
+// When you're done, kill and remove the container
+err = pool.Purge(resource)
+```


### PR DESCRIPTION
This adds the possibility to build and run a local Dockerfile.

The motivation behind this is to be able to use a local database image with pre-loaded schemas/data or custom parameters.

