### PR TITLE
Only create a TLS pool if DOCKER_CERT_PATH is set

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -101,7 +101,7 @@ func NewPool(endpoint string) (*Pool, error) {
 		}
 	}
 
-	if os.Getenv("DOCKER_CERT_PATH") == "" && shouldPreferTls(endpoint) {
+	if os.Getenv("DOCKER_CERT_PATH") != "" && shouldPreferTls(endpoint) {
 		return NewTLSPool(endpoint, os.Getenv("DOCKER_CERT_PATH"))
 	}
 


### PR DESCRIPTION
Credit goes to @explodingcamera for identifying this fix.  See #105 for detail.

Fixes #105.