### PR TITLE
Expose ExtraHosts

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -131,6 +131,7 @@ type RunOptions struct {
 	Mounts       []string
 	Links        []string
 	ExposedPorts []string
+	ExtraHosts   []string
 	Auth         dc.AuthConfiguration
 	PortBindings map[dc.Port][]dc.PortBinding
 }
@@ -224,6 +225,7 @@ func (d *Pool) RunWithOptions(opts *RunOptions) (*Resource, error) {
 			Binds:           opts.Mounts,
 			Links:           opts.Links,
 			PortBindings:    opts.PortBindings,
+			ExtraHosts:      opts.ExtraHosts,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
This will enable the user to add hostname mapping to the container.
Can be useful when mocking services when testing.

I would like to write a test for this, but I'm not sure it's worth it, it quite hard to test.