### PR TITLE
Remove d.Client.KillContainer in Purge method

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -255,10 +255,6 @@ func (d *Pool) Run(repository, tag string, env []string) (*Resource, error) {
 
 // Purge removes a container and linked volumes from docker.
 func (d *Pool) Purge(r *Resource) error {
-	if err := d.Client.KillContainer(dc.KillContainerOptions{ID: r.Container.ID}); err != nil {
-		return errors.Wrap(err, "")
-	}
-
 	if err := d.Client.RemoveContainer(dc.RemoveContainerOptions{ID: r.Container.ID, Force: true, RemoveVolumes: true}); err != nil {
 		return errors.Wrap(err, "")
 	}


### PR DESCRIPTION
This PR removes the need to call `d.Client.KillContainer()` since we are passing in `Force: true` in `RemoveContainer()`, which should take care of killing the container before it's removed.

This avoids returning an error on `Purge()` when the container is somehow killed (e.g. exited due to errors):
```
Failed to cleanup local container: : API error (500): Cannot kill container 6729d9e651eec207ba57585a5e774407904596a43e2877201be5a200409f7b26: Container 6729d9e651eec207ba57585a5e774407904596a43e2877201be5a200409f7b26 is not running
```