### PR TITLE
Fix imports in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ them for your tests.
 
 ## Installing and using Dockertest
 
-Using Dockertest is straightforward and simple. Check the [releases tab](https://github.com/ory-am/dockertest/releases)
+Using Dockertest is straightforward and simple. Check the [releases tab](https://github.com/ory/dockertest/releases)
 for available releases.
 
 To install dockertest, run
 
 ```
-go get gopkg.in/ory-am/dockertest.v3
+dep ensure -add github.com/ory/dockertest@v3.x.y
 ```
 
 ### Using Dockertest
@@ -49,7 +49,7 @@ package dockertest_test
 import (
 	"testing"
 	"log"
-	"gopkg.in/ory-am/dockertest.v3"
+	"github.com/ory/dockertest"
 	_ "github.com/go-sql-driver/mysql"
 	"database/sql"
 	"fmt"


### PR DESCRIPTION
According to https://github.com/ory/dockertest/issues/123 `gopkg.in` import should not be used anymore, but it's still mentioned in the project README.

This PR changes imports in the readme to the correct URL.