### PR TITLE
adds labels to docker config

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -161,6 +161,7 @@ type RunOptions struct {
 	ExposedPorts []string
 	ExtraHosts   []string
 	WorkingDir   string
+	Labels       map[string]string
 	Auth         dc.AuthConfiguration
 	PortBindings map[dc.Port][]dc.PortBinding
 }
@@ -250,6 +251,7 @@ func (d *Pool) RunWithOptions(opts *RunOptions) (*Resource, error) {
 			Mounts:       mounts,
 			ExposedPorts: exp,
 			WorkingDir:   wd,
+			Labels:       opts.Labels,
 		},
 		HostConfig: &dc.HostConfig{
 			PublishAllPorts: true,

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"testing"
 
-	dc "github.com/ory/dockertest/docker"
 	_ "github.com/lib/pq"
+	dc "github.com/ory/dockertest/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,6 +84,23 @@ func TestContainerWithName(t *testing.T) {
 		})
 	require.Nil(t, err)
 	assert.Equal(t, "/db", resource.Container.Name)
+
+	require.Nil(t, pool.Purge(resource))
+}
+
+func TestContainerWithLabels(t *testing.T) {
+	labels := map[string]string{
+		"my": "label",
+	}
+	resource, err := pool.RunWithOptions(
+		&RunOptions{
+			Name:       "db",
+			Repository: "postgres",
+			Tag:        "9.5",
+			Labels:     labels,
+		})
+	require.Nil(t, err)
+	assert.EqualValues(t, labels, resource.Container.Config.Labels, "labels don't match")
 
 	require.Nil(t, pool.Purge(resource))
 }


### PR DESCRIPTION
In using Dockertest in our pipelines it can be difficult to make sure resources get deleted after every job. Sometimes the test panics and the purge isn't ran. DinD is an option but comes with its own issues, another solve is to add the pipeline id to the the container labels and then clean the containers based on that id. 