### PR TITLE
Add Resource.Expire()

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,8 @@ Try cleaning up the images with [docker-cleanup-volumes](https://github.com/chad
 ### Removing old containers
 
 Sometimes container clean up fails. Check out
-[this stackoverflow question](http://stackoverflow.com/questions/21398087/how-to-delete-dockers-images) on how to fix this.
+[this stackoverflow question](http://stackoverflow.com/questions/21398087/how-to-delete-dockers-images) on how to fix this. You may also set an absolute lifetime on containers: 
+
+```go
+resource.Expire(60) // Tell docker to hard kill the container in 60 seconds
+```

--- a/dockertest.go
+++ b/dockertest.go
@@ -88,6 +88,16 @@ func (r *Resource) Close() error {
 	return r.pool.Purge(r)
 }
 
+// Expire sets a resource's associated container to terminate after a period has passed
+func (r *Resource) Expire(seconds uint) error {
+	go func() {
+		if err := r.pool.Client.StopContainer(r.Container.ID, seconds); err != nil {
+			// Error handling?
+		}
+	}()
+	return nil
+}
+
 // NewTLSPool creates a new pool given an endpoint and the certificate path. This is required for endpoints that
 // require TLS communication.
 func NewTLSPool(endpoint, certpath string) (*Pool, error) {
@@ -252,6 +262,7 @@ func (d *Pool) RunWithOptions(opts *RunOptions) (*Resource, error) {
 			ExposedPorts: exp,
 			WorkingDir:   wd,
 			Labels:       opts.Labels,
+			StopSignal:   "SIGWINCH", // to support timeouts
 		},
 		HostConfig: &dc.HostConfig{
 			PublishAllPorts: true,


### PR DESCRIPTION
Add `Resource.Expire()` to tell docker to hard kill Containers even if go exits without cleaning up.
- I picked `SIGWINCH` as the StopSignal as it seemed innocuous - tested with dynamo, mysql, & postgres.
- This could be better with `StopContainerWithContext` to allow successive test cases to reset the timeout.