### PR TITLE
Added options to modify host config

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -181,7 +181,8 @@ type RunOptions struct {
 	Privileged   bool
 }
 
-// BuildAndRunWithOptions builds and starts a docker container
+// BuildAndRunWithOptions builds and starts a docker container.
+// Optional modifier functions can be passed in order to change the hostconfig values not covered in RunOptions
 func (d *Pool) BuildAndRunWithOptions(dockerfilePath string, opts *RunOptions, hcOpts ...func(*dc.HostConfig)) (*Resource, error) {
 	// Set the Dockerfile folder as build context
 	dir, file := filepath.Split(dockerfilePath)
@@ -208,8 +209,12 @@ func (d *Pool) BuildAndRun(name, dockerfilePath string, env []string) (*Resource
 }
 
 // RunWithOptions starts a docker container.
+// Optional modifier functions can be passed in order to change the hostconfig values not covered in RunOptions
 //
 // pool.Run(&RunOptions{Repository: "mongo", Cmd: []string{"mongod", "--smallfiles"}})
+// pool.Run(&RunOptions{Repository: "mongo", Cmd: []string{"mongod", "--smallfiles"}}, func(hostConfig *dc.HostConfig) {
+//			hostConfig.ShmSize = shmemsize
+//		})
 func (d *Pool) RunWithOptions(opts *RunOptions, hcOpts ...func(*dc.HostConfig)) (*Resource, error) {
 	repository := opts.Repository
 	tag := opts.Tag

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -166,3 +166,19 @@ func TestExpire(t *testing.T) {
 
 	require.Nil(t, pool.Purge(resource))
 }
+
+func TestContainerWithShMzSize(t *testing.T) {
+	shmemsize := int64(1024 * 1024)
+	resource, err := pool.RunWithOptions(
+		&RunOptions{
+			Name:       "db",
+			Repository: "postgres",
+			Tag:        "9.5",
+		}, func(hostConfig *dc.HostConfig) {
+			hostConfig.ShmSize = shmemsize
+		})
+	require.Nil(t, err)
+	assert.EqualValues(t, shmemsize, resource.Container.HostConfig.ShmSize, "shmsize don't match")
+
+	require.Nil(t, pool.Purge(resource))
+}


### PR DESCRIPTION
## Related issue 148

Tries to address https://github.com/ory/dockertest/issues/148 . 

This pr extends the `RunWithOptions` method with a variadic functional option in order to be able to add  the missing `HostConfig` parameters not included in the `RunOptions` struct without breaking the compatibility.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ x ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ x ] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [ x  ] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have added necessary documentation within the code base (if appropriate)
