### PR TITLE
Provide API to remove containers by name

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -326,6 +326,34 @@ func (d *Pool) Run(repository, tag string, env []string) (*Resource, error) {
 	return d.RunWithOptions(&RunOptions{Repository: repository, Tag: tag, Env: env})
 }
 
+// RemoveContainerWithName find a container with the given name and removes it if present
+func (d *Pool) RemoveContainerWithName(containerName string) error {
+	containers, err := d.Client.ListContainers(dc.ListContainersOptions{
+		All: true,
+		Filters: map[string][]string{
+			"name": []string{containerName},
+		},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Error while listing containers with name %s", containerName)
+	}
+
+	if len(containers) == 0 {
+		return nil
+	}
+
+	err = d.Client.RemoveContainer(dc.RemoveContainerOptions{
+		ID:            containers[0].ID,
+		Force:         true,
+		RemoveVolumes: true,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Error while removing container with name %s", containerName)
+	}
+
+	return nil
+}
+
 // Purge removes a container and linked volumes from docker.
 func (d *Pool) Purge(r *Resource) error {
 	if err := d.Client.RemoveContainer(dc.RemoveContainerOptions{ID: r.Container.ID, Force: true, RemoveVolumes: true}); err != nil {

--- a/dockertest.go
+++ b/dockertest.go
@@ -326,8 +326,8 @@ func (d *Pool) Run(repository, tag string, env []string) (*Resource, error) {
 	return d.RunWithOptions(&RunOptions{Repository: repository, Tag: tag, Env: env})
 }
 
-// RemoveContainerWithName find a container with the given name and removes it if present
-func (d *Pool) RemoveContainerWithName(containerName string) error {
+// RemoveContainerByName find a container with the given name and removes it if present
+func (d *Pool) RemoveContainerByName(containerName string) error {
 	containers, err := d.Client.ListContainers(dc.ListContainersOptions{
 		All: true,
 		Filters: map[string][]string{

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -182,3 +182,25 @@ func TestContainerWithShMzSize(t *testing.T) {
 
 	require.Nil(t, pool.Purge(resource))
 }
+
+func TestRemoveContainerWithName(t *testing.T) {
+	_, err := pool.RunWithOptions(
+		&RunOptions{
+			Name:       "db",
+			Repository: "postgres",
+			Tag:        "9.5",
+		})
+	require.Nil(t, err)
+
+	err = pool.RemoveContainerWithName("db")
+	require.Nil(t, err)
+
+	resource, err := pool.RunWithOptions(
+		&RunOptions{
+			Name:       "db",
+			Repository: "postgres",
+			Tag:        "9.5",
+		})
+	require.Nil(t, err)
+	require.Nil(t, pool.Purge(resource))
+}

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -183,7 +183,7 @@ func TestContainerWithShMzSize(t *testing.T) {
 	require.Nil(t, pool.Purge(resource))
 }
 
-func TestRemoveContainerWithName(t *testing.T) {
+func TestRemoveContainerByName(t *testing.T) {
 	_, err := pool.RunWithOptions(
 		&RunOptions{
 			Name:       "db",
@@ -192,7 +192,7 @@ func TestRemoveContainerWithName(t *testing.T) {
 		})
 	require.Nil(t, err)
 
-	err = pool.RemoveContainerWithName("db")
+	err = pool.RemoveContainerByName("db")
 	require.Nil(t, err)
 
 	resource, err := pool.RunWithOptions(


### PR DESCRIPTION
Signed-off-by: Andrea Panattoni <panattoni.andrea@gmail.com>

## Related issue

Resolves #151 as discussed with @aeneasr 

## Proposed changes

Add API to remove a container by its name. I'm not completely sure about the function name. Feedbacks are welcome.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

NaN
