### PR TITLE
Remove Travis-CI Setting up description from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Use Docker to run your Go language integration tests against third party service
 - [Installing and using Dockertest](#installing-and-using-dockertest)
   - [Using Dockertest](#using-dockertest)
   - [Examples](#examples)
-  - [Setting up Travis-CI](#setting-up-travis-ci)
 - [Troubleshoot & FAQ](#troubleshoot-&-faq)
   - [Out of disk space](#out-of-disk-space)
   - [Removing old containers](#removing-old-containers)

--- a/README.md
+++ b/README.md
@@ -102,19 +102,6 @@ func TestSomething(t *testing.T) {
 
 We provide code examples for well known services in the [examples](examples/) directory, check them out!
 
-### Setting up Travis-CI
-
-You can run the Docker integration on Travis easily:
-
-```yml
-# Sudo is required for docker
-sudo: required
-
-# Enable docker
-services:
-  - docker
-```
-
 ## Troubleshoot & FAQ
 
 ### Out of disk space


### PR DESCRIPTION
Remove Setting up Travis-CI

## Related issue
Resolves #154  as discussed with @aeneasr .

## Proposed changes
Remove the section of Setting up Travis-CI from README.md.

## Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments
NaN