### PR TITLE
docs: Add error handling after container purging

### DIFF
--- a/examples/BuildDockerfile.md
+++ b/examples/BuildDockerfile.md
@@ -30,5 +30,7 @@ if err = pool.Retry(func() error {
 }
 
 // When you're done, kill and remove the container
-err = pool.Purge(resource)
+if err = pool.Purge(resource); err != nil {
+    log.Fatalf("Could not purge resource: %s", err)
+}
 ```

--- a/examples/Cassandra.md
+++ b/examples/Cassandra.md
@@ -43,5 +43,7 @@ if err := pool.Retry(func() error {
 }
 
 // When you're done, kill and remove the container
-err = pool.Purge(resource)
+if err = pool.Purge(resource); err != nil {
+    log.Fatalf("Could not purge resource: %s", err)
+}
 ```

--- a/examples/CockroachDB.md
+++ b/examples/CockroachDB.md
@@ -23,5 +23,7 @@ if err = pool.Retry(func() error {
 }
 
 // When you're done, kill and remove the container
-err = pool.Purge(resource)
+if err = pool.Purge(resource); err != nil {
+    log.Fatalf("Could not purge resource: %s", err)
+}
 ```

--- a/examples/Minio.md
+++ b/examples/Minio.md
@@ -38,5 +38,7 @@ if err := pool.Retry(func() error {
 }
 
 // When you're done, kill and remove the container
-err = pool.Purge(resource)
+if err = pool.Purge(resource); err != nil {
+    log.Fatalf("Could not purge resource: %s", err)
+}
 ```

--- a/examples/MongoDB.md
+++ b/examples/MongoDB.md
@@ -26,5 +26,7 @@ if err := pool.Retry(func() error {
 }
 
 // When you're done, kill and remove the container
-err = pool.Purge(resource)
+if err = pool.Purge(resource); err != nil {
+    log.Fatalf("Could not purge resource: %s", err)
+}
 ```

--- a/examples/MySQL.md
+++ b/examples/MySQL.md
@@ -24,5 +24,7 @@ if err = pool.Retry(func() error {
 }
 
 // When you're done, kill and remove the container
-err = pool.Purge(resource)
+if err = pool.Purge(resource); err != nil {
+    log.Fatalf("Could not purge resource: %s", err)
+}
 ```

--- a/examples/PostgreSQL.md
+++ b/examples/PostgreSQL.md
@@ -23,5 +23,7 @@ if err = pool.Retry(func() error {
 }
 
 // When you're done, kill and remove the container
-err = pool.Purge(resource)
+if err = pool.Purge(resource); err != nil {
+    log.Fatalf("Could not purge resource: %s", err)
+}
 ```

--- a/examples/Redis.md
+++ b/examples/Redis.md
@@ -22,5 +22,7 @@ if err = pool.Retry(func() error {
 }
 
 // When you're done, kill and remove the container
-err = pool.Purge(resource)
+if err = pool.Purge(resource); err != nil {
+    log.Fatalf("Could not purge resource: %s", err)
+}
 ```

--- a/examples/RethinkDB.md
+++ b/examples/RethinkDB.md
@@ -33,5 +33,7 @@ if err = pool.Retry(func() error {
 }
 
 // When you're done, kill and remove the container
-err = pool.Purge(resource)
+if err = pool.Purge(resource); err != nil {
+    log.Fatalf("Could not purge resource: %s", err)
+}
 ```


### PR DESCRIPTION
## Related issue
none.
As this has just minor changes, I created this PR without prior discussion.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes
Adds error handling after `pool.Purge` in example codes [README.md](https://github.com/ory/dockertest/blob/v3/README.md) is already doing.
It may be trivial, but I think it's worth adding so that users don't forget to add this handling when they are creating their own codes with referring these examples.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
