### PR TITLE
fix: set password to launch postgres container

### DIFF
--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestPostgres(t *testing.T) {
-	resource, err := pool.Run("postgres", "9.5", nil)
+	resource, err := pool.Run("postgres", "9.5", []string{"POSTGRES_PASSWORD=secret"})
 	require.Nil(t, err)
 	assert.NotEmpty(t, resource.GetPort("5432/tcp"))
 
@@ -101,6 +101,7 @@ func TestContainerWithLabels(t *testing.T) {
 			Repository: "postgres",
 			Tag:        "9.5",
 			Labels:     labels,
+			Env:        []string{"POSTGRES_PASSWORD=secret"},
 		})
 	require.Nil(t, err)
 	assert.EqualValues(t, labels, resource.Container.Config.Labels, "labels don't match")
@@ -116,6 +117,7 @@ func TestContainerWithPortBinding(t *testing.T) {
 			PortBindings: map[dc.Port][]dc.PortBinding{
 				"5432/tcp": {{HostIP: "", HostPort: "5433"}},
 			},
+			Env: []string{"POSTGRES_PASSWORD=secret"},
 		})
 	require.Nil(t, err)
 	assert.Equal(t, "5433", resource.GetPort("5432/tcp"))
@@ -142,7 +144,7 @@ func TestBuildImage(t *testing.T) {
 }
 
 func TestExpire(t *testing.T) {
-	resource, err := pool.Run("postgres", "9.5", nil)
+	resource, err := pool.Run("postgres", "9.5", []string{"POSTGRES_PASSWORD=secret"})
 	require.Nil(t, err)
 	assert.NotEmpty(t, resource.GetPort("5432/tcp"))
 
@@ -191,6 +193,7 @@ func TestContainerByName(t *testing.T) {
 			Name:       "db",
 			Repository: "postgres",
 			Tag:        "9.5",
+			Env:        []string{"POSTGRES_PASSWORD=secret"},
 		})
 	require.Nil(t, err)
 
@@ -208,6 +211,7 @@ func TestRemoveContainerByName(t *testing.T) {
 			Name:       "db",
 			Repository: "postgres",
 			Tag:        "9.5",
+			Env:        []string{"POSTGRES_PASSWORD=secret"},
 		})
 	require.Nil(t, err)
 
@@ -225,7 +229,7 @@ func TestRemoveContainerByName(t *testing.T) {
 }
 
 func TestExec(t *testing.T) {
-	resource, err := pool.Run("postgres", "9.5", nil)
+	resource, err := pool.Run("postgres", "9.5", []string{"POSTGRES_PASSWORD=secret"})
 	require.Nil(t, err)
 	assert.NotEmpty(t, resource.GetPort("5432/tcp"))
 	assert.NotEmpty(t, resource.GetBoundIP("5432/tcp"))
@@ -262,6 +266,7 @@ func TestNetworking_on_start(t *testing.T) {
 		Repository: "postgres",
 		Tag:        "9.5",
 		Networks:   []*Network{network},
+		Env:        []string{"POSTGRES_PASSWORD=secret"},
 	})
 	require.Nil(t, err)
 	defer resourceFirst.Close()
@@ -270,6 +275,7 @@ func TestNetworking_on_start(t *testing.T) {
 		Repository: "postgres",
 		Tag:        "11",
 		Networks:   []*Network{network},
+		Env:        []string{"POSTGRES_PASSWORD=secret"},
 	})
 	require.Nil(t, err)
 	defer resourceSecond.Close()
@@ -296,14 +302,14 @@ func TestNetworking_after_start(t *testing.T) {
 	require.Nil(t, err)
 	defer network.Close()
 
-	resourceFirst, err := pool.Run("postgres", "9.6", nil)
+	resourceFirst, err := pool.Run("postgres", "9.6", []string{"POSTGRES_PASSWORD=secret"})
 	require.Nil(t, err)
 	defer resourceFirst.Close()
 
 	err = resourceFirst.ConnectToNetwork(network)
 	require.Nil(t, err)
 
-	resourceSecond, err := pool.Run("postgres", "11", nil)
+	resourceSecond, err := pool.Run("postgres", "11", []string{"POSTGRES_PASSWORD=secret"})
 	require.Nil(t, err)
 	defer resourceSecond.Close()
 
@@ -329,7 +335,7 @@ func TestNetworking_after_start(t *testing.T) {
 	var stdout bytes.Buffer
 	exitCode, err := resourceFirst.Exec(
 		[]string{"psql", "-qtAX", "-h", resourceSecond.GetIPInNetwork(network), "-U", "postgres", "-c", "SHOW server_version"},
-		ExecOptions{StdOut: &stdout},
+		ExecOptions{StdOut: &stdout, Env: []string{"PGPASSWORD=secret"}},
 	)
 	require.Nil(t, err)
 	require.Zero(t, exitCode)


### PR DESCRIPTION
I fixed all broken tests in CI.

The tests were failed because the testing containers launched without default password.

## Related issue

Nothing

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Set a password as an environment variable on launching testing container.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).
