### PR TITLE
feat: add BuuildArgs to BuildOptions

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -306,6 +306,7 @@ type RunOptions struct {
 type BuildOptions struct {
 	Dockerfile string
 	ContextDir string
+	BuildArgs  []dc.BuildArg
 }
 
 // BuildAndRunWithBuildOptions builds and starts a docker container.
@@ -316,6 +317,7 @@ func (d *Pool) BuildAndRunWithBuildOptions(buildOpts *BuildOptions, runOpts *Run
 		Dockerfile:   buildOpts.Dockerfile,
 		OutputStream: ioutil.Discard,
 		ContextDir:   buildOpts.ContextDir,
+		BuildArgs:    buildOpts.BuildArgs,
 	})
 
 	if err != nil {


### PR DESCRIPTION

## Related issue

#242 Add BuildArgs to BuildOptions

## Proposed changes

I added BuildArgs field to BuildOptions struct for passing values on building an image.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).
