### PR TITLE
feat: Add user config run option

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -300,6 +300,7 @@ type RunOptions struct {
 	Auth         dc.AuthConfiguration
 	PortBindings map[dc.Port][]dc.PortBinding
 	Privileged   bool
+	User         string
 }
 
 // BuildOptions is used to pass in optional parameters when building a container
@@ -433,6 +434,7 @@ func (d *Pool) RunWithOptions(opts *RunOptions, hcOpts ...func(*dc.HostConfig)) 
 			WorkingDir:   wd,
 			Labels:       opts.Labels,
 			StopSignal:   "SIGWINCH", // to support timeouts
+			User:         opts.User,
 		},
 		HostConfig:       &hostConfig,
 		NetworkingConfig: &networkingConfig,

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -109,6 +109,26 @@ func TestContainerWithLabels(t *testing.T) {
 	require.Nil(t, pool.Purge(resource))
 }
 
+func TestContainerWithUser(t *testing.T) {
+	user := "1001:1001"
+	resource, err := pool.RunWithOptions(
+		&RunOptions{
+			Name:       "db",
+			Repository: "postgres",
+			Tag:        "9.5",
+			User:       user,
+			Env:        []string{"POSTGRES_PASSWORD=secret"},
+		})
+	require.Nil(t, err)
+	assert.EqualValues(t, user, resource.Container.Config.User, "users don't match")
+
+	res, err := pool.Client.InspectContainer(resource.Container.ID)
+	require.Nil(t, err)
+	assert.Equal(t, user, res.Config.User)
+
+	require.Nil(t, pool.Purge(resource))
+}
+
 func TestContainerWithPortBinding(t *testing.T) {
 	resource, err := pool.RunWithOptions(
 		&RunOptions{


### PR DESCRIPTION
## Related issue
#253 
@aeneasr 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes
Add a user RunOption field to specify the uid:gid to run a docker container with.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
