### PR TITLE
chore: update repository template to cb0b2b06

### DIFF
--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -25,4 +25,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issueLabels: upstream,good first issue,help wanted
           issueLimit: ${{ github.event.inputs.issueLimit || '5' }}
-          ignore: .git,docker


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/cb0b2b06e62928c5d809c6f21794d147b6511cd4.