### PR TITLE
chore: update repository template to 1e38ec4e

### DIFF
--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -25,4 +25,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issueLabels: upstream,good first issue,help wanted
           issueLimit: ${{ github.event.inputs.issueLimit || '5' }}
-          ignore: .git,docker


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/1e38ec4e626751a13ecd6f35c1aef2517c88dd65.