### PR TITLE
chore: update repository template to c704df8e

### DIFF
--- a/.github/CODEOWNER
+++ b/.github/CODEOWNER
@@ -1,0 +1,1 @@
+*       @ory/maintainers


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/c704df8ef4892cb97ccfe968c2300280ed58c055.