### PR TITLE
fix: lock before setting client api version

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -824,9 +824,9 @@ func (c *Client) StartContainerWithContext(id string, hostConfig *HostConfig, ct
 
 func (c *Client) startContainer(id string, hostConfig *HostConfig, opts doOptions) error {
 	path := "/containers/" + id + "/start"
-	if c.serverAPIVersion == nil {
-		c.checkAPIVersion()
-	}
+
+	c.checkAPIVersion()
+
 	if c.serverAPIVersion != nil && c.serverAPIVersion.LessThan(apiVersion124) {
 		opts.data = hostConfig
 		opts.forceJSON = true


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
This PR intends to add concurrency safety to Client.serverAPIVersion so that Client.StartContainer can be invoked concurrently/in parallel. This enables integration tests to run in parallel with the race detector enabled go test -race and avoid false positive race conditions originating from the dockertest package.

## Related issue(s)
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

This aims to address #290

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

I'm finding it very difficult to recreate the race condition I observed in #290, but it is clear that the `Client` implementation is prone to concurrent writes.
