### PR TITLE
fix: Add compatibility to golang 386

### DIFF
--- a/docker/env.go
+++ b/docker/env.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"math"
+	"math/big"
 )
 
 // Env represents a list of key-pair represented in the form KEY=VALUE.
@@ -51,7 +53,7 @@ func (env *Env) SetBool(key string, value bool) {
 //
 // It the value cannot be represented as an integer, it returns -1.
 func (env *Env) GetInt(key string) int {
-	return int(env.GetInt64(key))
+	return parse64(env.GetInt64(key))
 }
 
 // SetInt defines an integer value to the given key.
@@ -169,4 +171,11 @@ func (env *Env) Map() map[string]string {
 		}
 	}
 	return m
+}
+func parse64(x int64) int {
+	if 32 << uintptr(^uintptr(0) >> 63) == 32 {
+		return int(new(big.Int).Mod(big.NewInt(x), big.NewInt(math.MaxInt32)).Int64())
+	} else {
+		return int(x)
+	}
 }


### PR DESCRIPTION
In golang 64 this code will work without any problem at all, but in golang 386 it needs to make sure the overflow is treated carefully, this is a solution that does not require any breaking/alerting.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.

P.S. I understand I'm supposed to suggest edits to the `master` branch but couldn't find a corresponding issue there