### PR TITLE
Update README.md - Fix confusion in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ func TestMain(m *testing.M) {
 		}
 		return db.Ping()
 	}); err != nil {
-		log.Fatalf("Could not connect to docker: %s", err)
+		log.Fatalf("Could not connect to database: %s", err)
 	}
 
 	code := m.Run()


### PR DESCRIPTION
The log statement for a DB connection failure is a copy of the log statement for docker connection failure.

May lead users to spend a long time debugging docker while the actual problem is the database.

I accept the CLA.