### PR TITLE
feat: Add platform param to build options

### DIFF
--- a/docker/image.go
+++ b/docker/image.go
@@ -475,6 +475,7 @@ type BuildImageOptions struct {
 	CgroupParent        string             `qs:"cgroupparent"`
 	SecurityOpt         []string           `qs:"securityopt"`
 	Target              string             `gs:"target"`
+	Platform            string             `qs:"platform"`
 	Context             context.Context
 }
 

--- a/dockertest.go
+++ b/dockertest.go
@@ -309,6 +309,7 @@ type BuildOptions struct {
 	Dockerfile string
 	ContextDir string
 	BuildArgs  []dc.BuildArg
+	Platform   string
 }
 
 // BuildAndRunWithBuildOptions builds and starts a docker container.
@@ -320,6 +321,7 @@ func (d *Pool) BuildAndRunWithBuildOptions(buildOpts *BuildOptions, runOpts *Run
 		OutputStream: ioutil.Discard,
 		ContextDir:   buildOpts.ContextDir,
 		BuildArgs:    buildOpts.BuildArgs,
+		Platform:     buildOpts.Platform,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This is a first approach at adding the platform param to the build options. This seems to be enough in my case and I can emulate linux/amd64 on my Mac m1, but it's worth noting that it doesn't look like the /containers/create endpoint has the platform as a param yet.

## Related issue(s)

Solves #283 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

I'm not sure on what kind of test I should add to this, I await for mantainers' review
