### PR TITLE
feat: preset RunOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ func TestSomething(t *testing.T) {
 
 We provide code examples for well known services in the [examples](examples/) directory, check them out!
 
+### Presets
+
+Presets are predefined `RunOptions` configs that can be passed into `pool.RunWithOptions`.
+```go
+	resource, err := pool.RunWithOptions(Postgres(WithTag("11.2")))
+    if err != nil {
+		return err
+    }
+```
+
 ## Troubleshoot & FAQ
 
 ### Out of disk space

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -92,6 +92,22 @@ func TestContainerWithName(t *testing.T) {
 	require.Nil(t, pool.Purge(resource))
 }
 
+func TestPool_RunWithOptions_Preset_Postgres(t *testing.T) {
+	resource, err := pool.RunWithOptions(Postgres(WithTag("11.2")))
+	require.Nil(t, err)
+
+	assert.Equal(t, fmt.Sprintf("postgres:11.2"), resource.Container.Config.Image)
+	require.Nil(t, pool.Purge(resource))
+}
+
+func TestPool_RunWithOptions_Preset_Cassandra(t *testing.T) {
+	resource, err := pool.RunWithOptions(Cassandra())
+	require.Nil(t, err)
+
+	assert.Equal(t, fmt.Sprintf("cassandra:latest"), resource.Container.Config.Image)
+	require.Nil(t, pool.Purge(resource))
+}
+
 func TestContainerWithLabels(t *testing.T) {
 	labels := map[string]string{
 		"my": "label",

--- a/presets.go
+++ b/presets.go
@@ -1,0 +1,101 @@
+package dockertest
+
+// RunOption is a functional option that manipulates the default RunOptions.
+type RunOption func(*RunOptions)
+
+// WithTag allows for clients to define the tag they wish.
+func WithTag(tag string) RunOption {
+	return func(options *RunOptions) {
+		options.Tag = tag
+	}
+}
+
+// WithEnv allows for clients to define the environment variables they wish.
+func WithEnv(env []string) RunOption {
+	return func(options *RunOptions) {
+		options.Env = env
+	}
+}
+
+// WithExposedPorts allows for clients to define the exposed ports.
+func WithExposedPorts(ports []string) RunOption {
+	return func(options *RunOptions) {
+		options.ExposedPorts = ports
+	}
+}
+
+// WithCMD allows for clients to define the command they wish.
+func WithCMD(cmd []string) RunOption {
+	return func(options *RunOptions) {
+		options.Cmd = cmd
+	}
+}
+
+// Postgres returns a default RunOptions config for postgres with ability to overwrite the values.
+func Postgres(opts ...RunOption) *RunOptions {
+	r := &RunOptions{
+		Repository: "postgres",
+		Tag:        "latest",
+		Env: []string{
+			"POSTGRES_PASSWORD=secret",
+			"POSTGRES_USER=user_name",
+			"POSTGRES_DB=dbname",
+			"listen_addresses='*'",
+		},
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// Cassandra returns a default RunOptions config for cassandra with ability to overwrite the values.
+func Cassandra(opts ...RunOption) *RunOptions {
+	r := &RunOptions{
+		Repository: "cassandra",
+		Tag:        "latest",
+		Mounts:     []string{"/tmp/local-cassandra:/etc/cassandra"},
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// MySQL returns a default RunOptions config for MySQL with ability to overwrite the values.
+func MySQL(opts ...RunOption) *RunOptions {
+	r := &RunOptions{
+		Repository: "mysql",
+		Tag:        "latest",
+		Env: []string{
+			"MYSQL_ROOT_PASSWORD=secret",
+		},
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// Redis returns a default RunOptions config for redis with ability to overwrite the values.
+func Redis(opts ...RunOption) *RunOptions {
+	r := &RunOptions{
+		Repository: "bitnami/redis",
+		Tag:        "latest",
+		Env: []string{
+			"ALLOW_EMPTY_PASSWORD=yes",
+		},
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}


### PR DESCRIPTION
The idea for this is my `RunOptions` don't vary a whole lot and rather than copying the config from project-to-project, I thought it would be nice if `dockertest` offered some presets. The presets have been created based on the examples given in `/examples`

## Related issue(s)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
