### PR TITLE
docs: use official mongo driver with latest version

### DIFF
--- a/examples/MongoDB.md
+++ b/examples/MongoDB.md
@@ -1,32 +1,80 @@
 ```go
-var db *mgo.Session
-var err error
+package mongodb
 
-pool, err := dockertest.NewPool("")
-if err != nil {
-    log.Fatalf("Could not connect to docker: %s", err)
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var dbClient *mongo.Client
+
+func TestMain(m *testing.M) {
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		log.Fatalf("Could not connect to docker: %s", err)
+	}
+
+	// pull mongodb docker image for version 5.0
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "mongo",
+		Tag:        "5.0",
+		Env: []string{
+			// username and password for mongodb superuser
+			"MONGO_INITDB_ROOT_USERNAME=root",
+			"MONGO_INITDB_ROOT_PASSWORD=password",
+		},
+	}, func(config *docker.HostConfig) {
+		// set AutoRemove to true so that stopped container goes away by itself
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{
+			Name: "no",
+		}
+	})
+	if err != nil {
+		log.Fatalf("Could not start resource: %s", err)
+	}
+
+	// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
+	err = pool.Retry(func() error {
+		var err error
+		dbClient, err = mongo.Connect(
+			context.TODO(),
+			options.Client().ApplyURI(
+				fmt.Sprintf("mongodb://root:password@localhost:%s", resource.GetPort("27017/tcp")),
+			),
+		)
+		if err != nil {
+			return err
+		}
+		return dbClient.Ping(context.TODO(), nil)
+	})
+
+	if err != nil {
+		log.Fatalf("Could not connect to docker: %s", err)
+	}
+
+	// run tests
+	code := m.Run()
+
+	// When you're done, kill and remove the container
+	if err = pool.Purge(resource); err != nil {
+		log.Fatalf("Could not purge resource: %s", err)
+	}
+
+	// disconnect mongodb client
+	if err = dbClient.Disconnect(context.TODO()); err != nil {
+		panic(err)
+	}
+
+	os.Exit(code)
 }
 
-resource, err := pool.Run("mongo", "3.0", nil)
-if err != nil {
-    log.Fatalf("Could not start resource: %s", err)
-}
-
-// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
-if err := pool.Retry(func() error {
-    var err error
-    db, err = mgo.Dial(fmt.Sprintf("localhost:%s", resource.GetPort("27017/tcp")))
-    if err != nil {
-        return err
-    }
-
-    return db.Ping()
-}); err != nil {
-    log.Fatalf("Could not connect to docker: %s", err)
-}
-
-// When you're done, kill and remove the container
-if err = pool.Purge(resource); err != nil {
-    log.Fatalf("Could not purge resource: %s", err)
-}
 ```


### PR DESCRIPTION
Updates the MongoDB example to use the official MongoDB drivers (go.mongodb.org/mongo-driver/mongo) as mgo is currently unmaintained.

## Related issue(s)

There is no existing issue for this PR but I have a working demo [here](https://github.com/mainawycliffe/todo-dockertest-golang-mongo-demo/blob/main/todos/todos_test.go).

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
