### PR TITLE
fix: added check for overwriting runopts.repository

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -328,7 +328,9 @@ func (d *Pool) BuildAndRunWithBuildOptions(buildOpts *BuildOptions, runOpts *Run
 		return nil, errors.Wrap(err, "")
 	}
 
-	runOpts.Repository = runOpts.Name
+	if runOpts.Repository == "" {
+		runOpts.Repository = runOpts.Name
+	}
 
 	return d.RunWithOptions(runOpts, hcOpts...)
 }
@@ -620,7 +622,7 @@ func (d *Pool) NetworksByName(name string) ([]Network, error) {
 			)
 		}
 	}
-	
+
 	return foundNetworks, nil
 }
 

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -443,3 +443,23 @@ func TestClientRaceCondition(t *testing.T) {
 		})
 	}
 }
+
+// regression test for #330
+func TestSameImageMultipleContainers(t *testing.T) {
+	pool, err := NewPool(docker)
+	require.NoError(t, err)
+
+	opts := &RunOptions{
+		Name:       "container1",
+		Repository: "postgres",
+		Tag:        "13.4",
+	}
+	first, err := pool.RunWithOptions(opts)
+	require.NoError(t, err)
+	defer pool.Purge(first)
+
+	opts.Name = "container2"
+	second, err := pool.RunWithOptions(opts)
+	require.NoError(t, err)
+	defer pool.Purge(second)
+}


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Currently, BuildAndRunWithBuildOptions will overwrite runOpts.Repository with runOpts.Name. This means that the container's name always has to be a valid image repository, which has the side effect of preventing multiple instances of the same image running as separate containers. This change fixes that. 

## Related issue(s)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

Closes #330.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x ] I have read the [security policy](../security/policy).
- [x ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x ] I have added tests that prove my fix is effective or that my feature
      works.
- [x ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
