### PR TITLE
fix: resource host for rootless containers

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -69,7 +69,11 @@ func (r *Resource) GetBoundIP(id string) string {
 		return ""
 	}
 
-	return m[0].HostIP
+	ip := m[0].HostIP
+	if ip == "0.0.0.0" || ip == "" {
+		return "localhost"
+	}
+	return ip
 }
 
 // GetHostPort returns a resource's published port with an address.
@@ -84,7 +88,7 @@ func (r *Resource) GetHostPort(portID string) string {
 	}
 
 	ip := m[0].HostIP
-	if ip == "0.0.0.0" {
+	if ip == "0.0.0.0" || ip == "" {
 		ip = "localhost"
 	}
 	return net.JoinHostPort(ip, m[0].HostPort)


### PR DESCRIPTION
This fixes `resource.GetHostPort` and `resource.GetBoundIP` returning an empty string for the host segment on rootless containers, where "localhost" should be used.

## Related issue(s)

Fixes #317 

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

I was able to test this fix works by using Hashicorp's Boundary and replacing in go.mod their pinned ory/dockertest with my fork's branch, which allowed it to successfully communicate with a container created using Podman.