### PR TITLE
fix: allow resource.Exec to correctly wait for process completion

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -117,13 +117,23 @@ func (r *Resource) Exec(cmd []string, opts ExecOptions) (exitCode int, err error
 		Container:    r.Container.ID,
 		Cmd:          cmd,
 		Env:          opts.Env,
-		AttachStderr: opts.StdErr != nil,
-		AttachStdout: opts.StdOut != nil,
+		AttachStderr: true,
+		AttachStdout: true,
 		AttachStdin:  opts.StdIn != nil,
 		Tty:          opts.TTY,
 	})
 	if err != nil {
 		return -1, errors.Wrap(err, "Create exec failed")
+	}
+
+	// Always attach stderr/stdout, even if not specified, to ensure that exec
+	// waits with opts.Detach as true (default)
+	// ref: https://github.com/fsouza/go-dockerclient/issues/838
+	if opts.StdErr == nil {
+		opts.StdErr = io.Discard
+	}
+	if opts.StdOut == nil {
+		opts.StdOut = io.Discard
 	}
 
 	err = r.pool.Client.StartExec(exec.ID, dc.StartExecOptions{

--- a/dockertest.go
+++ b/dockertest.go
@@ -127,7 +127,7 @@ func (r *Resource) Exec(cmd []string, opts ExecOptions) (exitCode int, err error
 	}
 
 	// Always attach stderr/stdout, even if not specified, to ensure that exec
-	// waits with opts.Detach as true (default)
+	// waits with opts.Detach as false (default)
 	// ref: https://github.com/fsouza/go-dockerclient/issues/838
 	if opts.StdErr == nil {
 		opts.StdErr = io.Discard

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -475,7 +475,6 @@ func TestExecStatus(t *testing.T) {
 		Tag:        "3.16",
 		Cmd:        []string{"tail", "-f", "/dev/null"},
 	})
-	//resource, err := pool.Run("alpine", "3.16", nil)
 	defer resource.Close()
 	require.Nil(t, err)
 	exitCode, err := resource.Exec([]string{"/bin/false"}, ExecOptions{})

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -20,8 +20,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var docker = os.Getenv("DOCKER_URL")
-var pool *Pool
+var (
+	docker = os.Getenv("DOCKER_URL")
+	pool   *Pool
+)
 
 func TestMain(m *testing.M) {
 	var err error
@@ -65,7 +67,6 @@ func TestMongo(t *testing.T) {
 
 	err = pool.Retry(func() error {
 		response, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s", port))
-
 		if err != nil {
 			return err
 		}
@@ -197,7 +198,7 @@ func TestBuildImage(t *testing.T) {
 	dockerfilePath := dir + "/Dockerfile"
 	ioutil.WriteFile(dockerfilePath,
 		[]byte("FROM postgres:9.5"),
-		0644,
+		0o644,
 	)
 
 	resource, err := pool.BuildAndRun("postgres-test", dockerfilePath, nil)
@@ -219,7 +220,7 @@ ARG foo
 RUN echo -n $foo > /build-time-value
 CMD sleep 10
 `)),
-		0644,
+		0o644,
 	)
 
 	resource, err := pool.BuildAndRunWithBuildOptions(
@@ -466,4 +467,21 @@ func TestClientRaceCondition(t *testing.T) {
 			defer pool.Purge(resource)
 		})
 	}
+}
+
+func TestExecStatus(t *testing.T) {
+	resource, err := pool.RunWithOptions(&RunOptions{
+		Repository: "alpine",
+		Tag:        "3.16",
+		Cmd:        []string{"tail", "-f", "/dev/null"},
+	})
+	//resource, err := pool.Run("alpine", "3.16", nil)
+	defer resource.Close()
+	require.Nil(t, err)
+	exitCode, err := resource.Exec([]string{"/bin/false"}, ExecOptions{})
+	require.Nil(t, err)
+	require.Equal(t, 1, exitCode)
+	exitCode, err = resource.Exec([]string{"/bin/sh", "-c", "/bin/sleep 2 && exit 42"}, ExecOptions{})
+	require.Nil(t, err)
+	require.Equal(t, 42, exitCode)
 }


### PR DESCRIPTION
This bug was due to a bug in the vendored client library where `StartExec` would return early if stderr and stdout were not attached (even if `opts.Detatch` was `false`, which is the default. This fix always attaches them and falls back to `io.Discard` if the user does not provide their own readers.
- See: https://github.com/fsouza/go-dockerclient/issues/838

## Related Issue or Design Document
Fixes #372

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [X] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added the necessary documentation within the code base (if appropriate).
