### PR TITLE
fix: use npipe by default on Windows

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -270,7 +270,11 @@ func NewPool(endpoint string) (*Pool, error) {
 		} else if os.Getenv("DOCKER_URL") != "" {
 			endpoint = os.Getenv("DOCKER_URL")
 		} else if runtime.GOOS == "windows" {
-			endpoint = "http://localhost:2375"
+			if _, err := os.Stat(`\\.\pipe\docker_engine`); err == nil {
+				endpoint = "npipe:////./pipe/docker_engine"
+			} else {
+				endpoint = "http://localhost:2375"
+			}
 		} else {
 			endpoint = "unix:///var/run/docker.sock"
 		}


### PR DESCRIPTION
Docker on Windows listens on `\\.\pipe\docker_engine` by default. Previously it used `http://localhost:2375`, which is unsafer.

Since some people may still rely on the old http behavior, this is a backwards compatible change. It chooses the endpoint based on whether the default pipe exists or not.

Fixes #202

---

This makes dockertest package work on Windows with default Docker configuration.

## Related Issue or Design Document

This bug was reported in #202

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

The existing tests should cover that it works on Windows.