### PR TITLE
refactor: replace deprecated ioutil with io and os

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -6,7 +6,6 @@ package dockertest
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -340,7 +339,7 @@ func (d *Pool) BuildAndRunWithBuildOptions(buildOpts *BuildOptions, runOpts *Run
 	err := d.Client.BuildImage(dc.BuildImageOptions{
 		Name:         runOpts.Name,
 		Dockerfile:   buildOpts.Dockerfile,
-		OutputStream: ioutil.Discard,
+		OutputStream: io.Discard,
 		ContextDir:   buildOpts.ContextDir,
 		BuildArgs:    buildOpts.BuildArgs,
 		Platform:     buildOpts.Platform,

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -199,11 +198,10 @@ func TestContainerWithPortBinding(t *testing.T) {
 
 func TestBuildImage(t *testing.T) {
 	// Create Dockerfile in temp dir
-	dir, _ := ioutil.TempDir("", "dockertest")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	dockerfilePath := dir + "/Dockerfile"
-	ioutil.WriteFile(dockerfilePath,
+	os.WriteFile(dockerfilePath,
 		[]byte("FROM postgres:9.5"),
 		0o644,
 	)
@@ -217,11 +215,10 @@ func TestBuildImage(t *testing.T) {
 
 func TestBuildImageWithBuildArg(t *testing.T) {
 	// Create Dockerfile in temp dir
-	dir, _ := ioutil.TempDir("", "dockertest")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	dockerfilePath := dir + "/Dockerfile"
-	ioutil.WriteFile(dockerfilePath,
+	os.WriteFile(dockerfilePath,
 		[]byte((`FROM busybox
 ARG foo
 RUN echo -n $foo > /build-time-value

--- a/examples/FakeGoogleCloudStorage.md
+++ b/examples/FakeGoogleCloudStorage.md
@@ -18,7 +18,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -198,7 +198,7 @@ func readFile(client *storage.Client, bucketName, fileName string) ([]byte, erro
 		return nil, err
 	}
 	defer reader.Close()
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 func deleteFile(client *storage.Client, bucketName, fileName string) error {


### PR DESCRIPTION
This PR replaces deprecated in Go 1.16 [`io/ioutil`](https://pkg.go.dev/io/ioutil) package with `io` and `os`.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Replace was done with the help of [`gofmt`](https://pkg.go.dev/cmd/gofmt) and [`goimports`](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) tools:
```
gofmt -r 'ioutil.WriteFile -> os.WriteFile' -w .
gofmt -r 'ioutil.Discard -> io.Discard' -w .
gofmt -r 'ioutil.ReadAll -> io.ReadAll' -w .
goimports -w .
```

Changed `ioutil.TempDir` to [`t.TempDir`](https://pkg.go.dev/testing#T.TempDir) in tests.