### PR TITLE
chore: bump workflow actions; configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - run: make format

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -11,8 +11,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.18"
       - uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.17"
       - run: make test


### PR DESCRIPTION
This PR bump versions for GitHub workflow actions. Also, sets dependabot to bump GitHub actions weekly.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).
