### PR TITLE
refactor: replace pkg/errors with native error wrapping

### DIFF
--- a/docker/opts/env.go
+++ b/docker/opts/env.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // ValidateEnv validates an environment variable and returns it.
@@ -23,7 +21,7 @@ import (
 func ValidateEnv(val string) (string, error) {
 	arr := strings.Split(val, "=")
 	if arr[0] == "" {
-		return "", errors.Errorf("invalid environment variable: %s", val)
+		return "", fmt.Errorf("invalid environment variable: %s", val)
 	}
 	if len(arr) > 1 {
 		return val, nil

--- a/docker/opts/opts.go
+++ b/docker/opts/opts.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/docker/cli/cli/compose/loader"
 	units "github.com/docker/go-units"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -345,7 +344,7 @@ func (m *MemBytes) UnmarshalJSON(s []byte) error {
 func MountParser(mount string) (source, destination string, err error) {
 	spec, err := loader.ParseVolume(mount)
 	if err != nil {
-		return "", "", errors.Wrap(err, "Failed to parse mount")
+		return "", "", fmt.Errorf("Failed to parse mount: %w", err)
 	}
 
 	return spec.Source, spec.Target, nil

--- a/docker/pkg/system/rm.go
+++ b/docker/pkg/system/rm.go
@@ -4,12 +4,12 @@
 package system // import "github.com/ory/dockertest/v3/docker/pkg/system"
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"time"
 
 	"github.com/ory/dockertest/v3/docker/pkg/mount"
-	"github.com/pkg/errors"
 )
 
 // EnsureRemoveAll wraps `os.RemoveAll` to check for specific errors that can
@@ -69,7 +69,7 @@ func EnsureRemoveAll(dir string) error {
 		if mounted, _ := mount.Mounted(pe.Path); mounted {
 			if e := mount.Unmount(pe.Path); e != nil {
 				if mounted, _ := mount.Mounted(pe.Path); mounted {
-					return errors.Wrapf(e, "error while removing %s", dir)
+					return fmt.Errorf("error while removing %s: %w", dir, e)
 				}
 			}
 		}

--- a/dockertest.go
+++ b/dockertest.go
@@ -4,6 +4,7 @@
 package dockertest
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -16,7 +17,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	dc "github.com/ory/dockertest/v3/docker"
 	options "github.com/ory/dockertest/v3/docker/opts"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -125,7 +125,7 @@ func (r *Resource) Exec(cmd []string, opts ExecOptions) (exitCode int, err error
 		Tty:          opts.TTY,
 	})
 	if err != nil {
-		return -1, errors.Wrap(err, "Create exec failed")
+		return -1, fmt.Errorf("Create exec failed: %w", err)
 	}
 
 	// Always attach stderr/stdout, even if not specified, to ensure that exec
@@ -145,12 +145,12 @@ func (r *Resource) Exec(cmd []string, opts ExecOptions) (exitCode int, err error
 		Tty:          opts.TTY,
 	})
 	if err != nil {
-		return -1, errors.Wrap(err, "Start exec failed")
+		return -1, fmt.Errorf("Start exec failed: %w", err)
 	}
 
 	inspectExec, err := r.pool.Client.InspectExec(exec.ID)
 	if err != nil {
-		return -1, errors.Wrap(err, "Inspect exec failed")
+		return -1, fmt.Errorf("Inspect exec failed: %w", err)
 	}
 
 	return inspectExec.ExitCode, nil
@@ -177,18 +177,18 @@ func (r *Resource) ConnectToNetwork(network *Network) error {
 		dc.NetworkConnectionOptions{Container: r.Container.ID},
 	)
 	if err != nil {
-		return errors.Wrap(err, "Failed to connect container to network")
+		return fmt.Errorf("Failed to connect container to network: %w", err)
 	}
 
 	// refresh internal representation
 	r.Container, err = r.pool.Client.InspectContainer(r.Container.ID)
 	if err != nil {
-		return errors.Wrap(err, "Failed to refresh container information")
+		return fmt.Errorf("Failed to refresh container information: %w", err)
 	}
 
 	network.Network, err = r.pool.Client.NetworkInfo(network.Network.ID)
 	if err != nil {
-		return errors.Wrap(err, "Failed to refresh network information")
+		return fmt.Errorf("Failed to refresh network information: %w", err)
 	}
 
 	return nil
@@ -201,18 +201,18 @@ func (r *Resource) DisconnectFromNetwork(network *Network) error {
 		dc.NetworkConnectionOptions{Container: r.Container.ID},
 	)
 	if err != nil {
-		return errors.Wrap(err, "Failed to connect container to network")
+		return fmt.Errorf("Failed to connect container to network: %w", err)
 	}
 
 	// refresh internal representation
 	r.Container, err = r.pool.Client.InspectContainer(r.Container.ID)
 	if err != nil {
-		return errors.Wrap(err, "Failed to refresh container information")
+		return fmt.Errorf("Failed to refresh container information: %w", err)
 	}
 
 	network.Network, err = r.pool.Client.NetworkInfo(network.Network.ID)
 	if err != nil {
-		return errors.Wrap(err, "Failed to refresh network information")
+		return fmt.Errorf("Failed to refresh network information: %w", err)
 	}
 
 	return nil
@@ -242,7 +242,7 @@ func NewTLSPool(endpoint, certpath string) (*Pool, error) {
 
 	client, err := dc.NewTLSClient(endpoint, cert, key, ca)
 	if err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 
 	return &Pool{
@@ -259,7 +259,7 @@ func NewPool(endpoint string) (*Pool, error) {
 		if os.Getenv("DOCKER_MACHINE_NAME") != "" {
 			client, err := dc.NewClientFromEnv()
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to create client from environment")
+				return nil, fmt.Errorf("failed to create client from environment: %w", err)
 			}
 
 			return &Pool{Client: client}, nil
@@ -285,7 +285,7 @@ func NewPool(endpoint string) (*Pool, error) {
 
 	client, err := dc.NewClient(endpoint)
 	if err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 
 	return &Pool{
@@ -346,7 +346,7 @@ func (d *Pool) BuildAndRunWithBuildOptions(buildOpts *BuildOptions, runOpts *Run
 	})
 
 	if err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 
 	runOpts.Repository = runOpts.Name
@@ -426,7 +426,7 @@ func (d *Pool) RunWithOptions(opts *RunOptions, hcOpts ...func(*dc.HostConfig)) 
 			Tag:        tag,
 			Platform:   opts.Platform,
 		}, opts.Auth); err != nil {
-			return nil, errors.Wrap(err, "")
+			return nil, err
 		}
 	}
 
@@ -466,22 +466,22 @@ func (d *Pool) RunWithOptions(opts *RunOptions, hcOpts ...func(*dc.HostConfig)) 
 		NetworkingConfig: &networkingConfig,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 
 	if err := d.Client.StartContainer(c.ID, nil); err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 
 	c, err = d.Client.InspectContainer(c.ID)
 	if err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 
 	for _, network := range opts.Networks {
 		network.Network, err = d.Client.NetworkInfo(network.Network.ID)
 		if err != nil {
-			return nil, errors.Wrap(err, "")
+			return nil, err
 		}
 	}
 
@@ -535,7 +535,7 @@ func (d *Pool) RemoveContainerByName(containerName string) error {
 		},
 	})
 	if err != nil {
-		return errors.Wrapf(err, "Error while listing containers with name %s", containerName)
+		return fmt.Errorf("Error while listing containers with name %s: %w", containerName, err)
 	}
 
 	if len(containers) == 0 {
@@ -548,7 +548,7 @@ func (d *Pool) RemoveContainerByName(containerName string) error {
 		RemoveVolumes: true,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "Error while removing container with name %s", containerName)
+		return fmt.Errorf("Error while removing container with name %s: %w", containerName, err)
 	}
 
 	return nil
@@ -557,7 +557,7 @@ func (d *Pool) RemoveContainerByName(containerName string) error {
 // Purge removes a container and linked volumes from docker.
 func (d *Pool) Purge(r *Resource) error {
 	if err := d.Client.RemoveContainer(dc.RemoveContainerOptions{ID: r.Container.ID, Force: true, RemoveVolumes: true}); err != nil {
-		return errors.Wrap(err, "")
+		return err
 	}
 
 	return nil
@@ -588,7 +588,7 @@ func (d *Pool) CurrentContainer() (*Resource, error) {
 	// docker daemon puts short container id into hostname
 	hostname, err := os.Hostname()
 	if err != nil {
-		return nil, errors.Wrap(err, "Get hostname failed")
+		return nil, fmt.Errorf("Get hostname failed: %w", err)
 	}
 
 	container, err := d.Client.InspectContainer(hostname)
@@ -601,7 +601,7 @@ func (d *Pool) CurrentContainer() (*Resource, error) {
 	case *dc.NoSuchContainer:
 		return nil, ErrNotInContainer
 	default:
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 }
 
@@ -615,7 +615,7 @@ func (d *Pool) CreateNetwork(name string, opts ...func(config *dc.CreateNetworkO
 
 	network, err := d.Client.CreateNetwork(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 
 	return &Network{
@@ -628,7 +628,7 @@ func (d *Pool) CreateNetwork(name string, opts ...func(config *dc.CreateNetworkO
 func (d *Pool) NetworksByName(name string) ([]Network, error) {
 	networks, err := d.Client.ListNetworks()
 	if err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 
 	var foundNetworks []Network

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/opencontainers/runc v1.1.5
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/net v0.8.0
@@ -33,6 +32,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect


### PR DESCRIPTION
This PR replaces the deprecated package [github.com/pkg/errors](https://github.com/pkg/errors) with the native error wrapping using `%w`.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

`github.com/pkg/errors` is useful only for one function [`WithStack`](https://pkg.go.dev/github.com/pkg/errors#WithStack). But this function is not used in the `dockertest`. So, we can replace this package with the native error wrapping that appears [in Go 1.13](https://go.dev/blog/go1.13-errors)).

Changes:
- Replace `errors.Wrap(err, "...")`, `errors.Wrapf(err, "...")`  with `fmt.Errorf("...: %w", err)`.
- Replace `errors.Errorf` with `fmt.Errorf`.
- Replace `errors.Wrap(err, "")` with `err`.