### PR TITLE
added AuthConfigs to BuildOptions and pass that to BuildImage

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -331,6 +331,7 @@ type BuildOptions struct {
 	ContextDir string
 	BuildArgs  []dc.BuildArg
 	Platform   string
+	Auth       dc.AuthConfigurations
 }
 
 // BuildAndRunWithBuildOptions builds and starts a docker container.
@@ -343,6 +344,7 @@ func (d *Pool) BuildAndRunWithBuildOptions(buildOpts *BuildOptions, runOpts *Run
 		ContextDir:   buildOpts.ContextDir,
 		BuildArgs:    buildOpts.BuildArgs,
 		Platform:     buildOpts.Platform,
+		AuthConfigs:  buildOpts.Auth,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Please consider this a 'naive PR' - we ran into an issue where although it was possible to pass along authentication to the run commands but not the build.

This fixes it, but I'm wondering why this wasn't already possible or whether I'm doing something else wrong

And i'm wondering why `dockertest` did not use already present and logged in `~/.docker/config.json`

Either way, thanks for `dockertest`, it has already been used tens of thousands of times by us :)

