### PR TITLE
fix: add missing closing response body

### DIFF
--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -76,6 +76,7 @@ func TestMongo(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		defer response.Body.Close()
 
 		if response.StatusCode != http.StatusOK {
 			return fmt.Errorf("could not connect to resource")

--- a/examples/Minio.md
+++ b/examples/Minio.md
@@ -39,6 +39,7 @@ if err := pool.Retry(func() error {
     if err != nil {
         return err
     }
+    defer resp.Body.Close()
     if resp.StatusCode != http.StatusOK {
         return fmt.Errorf("status code not OK")
     }


### PR DESCRIPTION
Fix possible resource leaks by adding a statement that closes a response body.

## Related Issue or Design Document


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

From the [documentation](https://pkg.go.dev/net/http):
> The caller must close the response body when finished with it

Also, see this [article](https://golang50shad.es/index.html#close_http_resp_body) for a deep dive into the problem.
