### PR TITLE
chore: remove direct dependency on gotest.tools/v3

### DIFF
--- a/docker/types/filters/parse_test.go
+++ b/docker/types/filters/parse_test.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"testing"
 
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseArgs(t *testing.T) {
@@ -25,10 +25,10 @@ func TestParseArgs(t *testing.T) {
 
 	for i := range flagArgs {
 		args, err = ParseFlag(flagArgs[i], args)
-		assert.NilError(t, err)
+		require.NoError(t, err)
 	}
-	assert.Check(t, is.Len(args.Get("created"), 1))
-	assert.Check(t, is.Len(args.Get("image.name"), 2))
+	assert.Len(t, args.Get("created"), 1)
+	assert.Len(t, args.Get("image.name"), 2)
 }
 
 func TestParseArgsEdgeCase(t *testing.T) {
@@ -234,7 +234,7 @@ func TestArgsMatch(t *testing.T) {
 	}
 
 	for args, field := range matches {
-		assert.Check(t, args.Match(field, source),
+		assert.Truef(t, args.Match(field, source),
 			"Expected field %s to match %s", field, source)
 	}
 
@@ -258,7 +258,7 @@ func TestArgsMatch(t *testing.T) {
 	}
 
 	for args, field := range differs {
-		assert.Check(t, !args.Match(field, source), "Expected field %s to not match %s", field, source)
+		assert.Falsef(t, args.Match(field, source), "Expected field %s to not match %s", field, source)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sys v0.21.0
-	gotest.tools/v3 v3.5.1
 )
 
 require (
@@ -39,4 +38,5 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/v3 v3.5.1 // indirect
 )


### PR DESCRIPTION
## Related Issue or Design Document

The PR replaces usages of `gotest.tools/v3` with `github.com/stretchr/testify` because the latter is mainly used in the repo tests.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

This refactoring removes `gotest.tools/v3` from direct dependencies, which can be seen in the `go.mod`.