### PR TITLE
docs: remove outdated dep install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ To install dockertest, run
 go get -u github.com/ory/dockertest/v3
 ```
 
-or
-
-```
-dep ensure -add github.com/ory/dockertest@v3.x.y
-```
-
 ### Using Dockertest
 
 ```go

--- a/docker/README.markdown
+++ b/docker/README.markdown
@@ -111,15 +111,6 @@ Running `make test` will check all of these. If your editor does not
 automatically call `gofmt -s`, `make fmt` will format all go files in this
 repository.
 
-## Vendoring
-
-go-dockerclient uses [dep](https://github.com/golang/dep/) for vendoring. If
-you're using dep, you should be able to pick go-dockerclient releases and get
-the proper dependencies.
-
-With other vendoring tools, users might need to specify go-dockerclient's
-dependencies manually.
-
 ## Using with Docker 1.9 and Go 1.4
 
 There's a tag for using go-dockerclient with Docker 1.9 (which requires


### PR DESCRIPTION
## Related Issue or Design Document

The PR removes mention of the deprecated [`dep`](https://github.com/golang/dep) in the README.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

`dep` has been deprecated since Sep 9, 2020.