### PR TITLE
chore: replace deprecated ioutil.TempDir with os.MkdirTemp

### DIFF
--- a/docker/pkg/ioutils/temp_unix.go
+++ b/docker/pkg/ioutils/temp_unix.go
@@ -8,7 +8,7 @@ package ioutils // import "github.com/ory/dockertest/v3/docker/pkg/ioutils"
 
 import "os"
 
-// TempDir on Unix systems is equivalent to ioutil.TempDir.
+// TempDir on Unix systems is equivalent to os.MkdirTemp.
 func TempDir(dir, prefix string) (string, error) {
 	return os.MkdirTemp(dir, prefix)
 }

--- a/docker/pkg/ioutils/temp_windows.go
+++ b/docker/pkg/ioutils/temp_windows.go
@@ -4,14 +4,14 @@
 package ioutils // import "github.com/ory/dockertest/v3/docker/pkg/ioutils"
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/ory/dockertest/v3/docker/pkg/longpath"
 )
 
-// TempDir is the equivalent of ioutil.TempDir, except that the result is in Windows longpath format.
+// TempDir is the equivalent of os.MkdirTemp, except that the result is in Windows longpath format.
 func TempDir(dir, prefix string) (string, error) {
-	tempDir, err := ioutil.TempDir(dir, prefix)
+	tempDir, err := os.MkdirTemp(dir, prefix)
 	if err != nil {
 		return "", err
 	}

--- a/docker/pkg/system/filesys_windows.go
+++ b/docker/pkg/system/filesys_windows.go
@@ -264,7 +264,7 @@ func nextSuffix() string {
 	return strconv.Itoa(int(1e9 + r%1e9))[1:]
 }
 
-// TempFileSequential is a copy of ioutil.TempFile, modified to use sequential
+// TempFileSequential is a copy of os.CreateTemp, modified to use sequential
 // file access. Below is the original comment from golang:
 // TempFile creates a new temporary file in the directory dir
 // with a name beginning with prefix, opens the file for reading


### PR DESCRIPTION
## Related Issue or Design Document

The PR replaces usages of the deprecated [`ioutil.TempDir`](https://pkg.go.dev/io/ioutil#TempDir) with `os.MkdirTemp`.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Follows changes in the PR #499.