### PR TITLE
refactor: simplify inspectContainerWithRetries

### DIFF
--- a/dockertest.go
+++ b/dockertest.go
@@ -508,15 +508,12 @@ func (d *Pool) RunWithOptions(opts *RunOptions, hcOpts ...func(*dc.HostConfig)) 
 // inspectContainerWithRetries will repeat the inspect call until the container has port bindings assigned.
 func (d *Pool) inspectContainerWithRetries(id string) (*dc.Container, error) {
 	const maxRetries = 10
-	var (
-		retryNum int
-		c        *dc.Container
-		err      error
-	)
-	for retryNum <= maxRetries {
-		if retryNum > 0 {
+	var c *dc.Container
+	for retry := 0; retry <= maxRetries; retry++ {
+		if retry > 0 {
 			time.Sleep(100 * time.Millisecond)
 		}
+		var err error
 		c, err = d.Client.InspectContainer(id)
 		if err != nil {
 			return nil, err
@@ -531,9 +528,8 @@ func (d *Pool) inspectContainerWithRetries(id string) (*dc.Container, error) {
 		}(); !hasEmptyPortBindings {
 			return c, nil
 		}
-		retryNum++
 	}
-	return c, err
+	return c, nil
 }
 
 // Run starts a docker container.


### PR DESCRIPTION
The PR refactors implementation of the `inspectContainerWithRetries` function by placing `retry` into the init and post statements in the `for` loop. Also, reduces the scope of the `err` variable.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Follows #533
