### PR TITLE
fix: resolve v4 refactor regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Dockertest supports running any Docker Image from Docker Hub and Dockerfile.
 When developing applications, it is often necessary to use services that talk to
 a database system. Unit testing these services can be cumbersome because mocking
 rewriting at least some, if not all mocks. The same goes for API changes in the
-database/DBAL is strenuous. Making slight changes to the schema implies
-DBAL.
+database/DBAL is strenuous. Making slight changes to the schema implies DBAL.
 
 To avoid this, it is smarter to test these specific services against a real
 database that is destroyed after testing. Docker is the perfect system for

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,7 +20,7 @@ This guide helps you migrate from dockertest v3 to v4.
 | `defer pool.Purge(resource)`                                                        | `resource.Cleanup(t)` or automatic via `pool.Cleanup()`                                                        |
 | No context support                                                                  | Context throughout                                                                                             |
 | Manual container reuse                                                              | Automatic container reuse by default                                                                           |
-| Generic errors                                                                      | Sentinel errors (`ErrImagePullFailed`, `ErrTimeout`)                                                           |
+| Generic errors                                                                      | Sentinel errors (`ErrImagePullFailed`) plus context errors (`context.DeadlineExceeded`)                        |
 
 ## Breaking Changes
 
@@ -130,7 +130,7 @@ resource, err := pool.Run(ctx, "postgres", dockertest.WithTag("14"))
 if errors.Is(err, dockertest.ErrImagePullFailed) {
     // Handle image pull failure
 }
-if errors.Is(err, dockertest.ErrTimeout) {
+if errors.Is(err, context.DeadlineExceeded) {
     // Handle timeout
 }
 ```

--- a/build.go
+++ b/build.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/distribution/reference"
 	mobyclient "github.com/moby/moby/client"
 )
 
@@ -131,16 +132,20 @@ func (p *Pool) BuildAndRun(ctx context.Context, name string, buildOpts *BuildOpt
 		return nil, fmt.Errorf("failed to drain build response: %w", drainErr)
 	}
 
-	// Run the built image
-	// Use the first tag as the repository
-	// Add noPull option since we just built the image locally
+	// Run the built image.
+	repository, tag, err := splitImageReference(tags[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid image reference %q: %w", tags[0], err)
+	}
+
+	// Add noPull option since we just built the image locally.
 	noPullOpt := RunOption(func(rc *runConfig) error {
 		rc.noPull = true
 		return nil
 	})
-	allOpts := append([]RunOption{noPullOpt}, runOpts...)
+	allOpts := append(runOpts, noPullOpt, WithTag(tag))
 
-	resource, err := p.Run(ctx, tags[0], allOpts...)
+	resource, err := p.Run(ctx, repository, allOpts...)
 	if err != nil {
 		cleanupCtx := context.WithoutCancel(ctx)
 		for _, tag := range tags {
@@ -162,6 +167,21 @@ func (p *Pool) BuildAndRunT(t TestingTB, name string, buildOpts *BuildOptions, r
 	}
 
 	return r
+}
+
+func splitImageReference(ref string) (repository, tag string, err error) {
+	named, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return "", "", err
+	}
+
+	repository = reference.FamiliarName(named)
+	tag = "latest"
+	if tagged, ok := named.(reference.Tagged); ok {
+		tag = tagged.Tag()
+	}
+
+	return repository, tag, nil
 }
 
 // createBuildContext creates a tar archive of the given directory for Docker build context.

--- a/build_test.go
+++ b/build_test.go
@@ -197,3 +197,74 @@ func TestBuildAndRunWithBuildContext(t *testing.T) {
 	// Cleanup
 	r.CloseT(t)
 }
+
+func TestBuildAndRunWithTaggedName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	pool := dockertest.NewPoolT(t, "")
+	tmpDir := t.TempDir()
+
+	dockerfile := `FROM alpine:latest
+CMD ["sleep", "300"]
+`
+	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
+	if err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o644); err != nil {
+		t.Fatalf("Failed to write Dockerfile: %v", err)
+	}
+
+	imageRef := "dockertest-build-tagged:v1"
+	r := pool.BuildAndRunT(t, imageRef, &dockertest.BuildOptions{
+		Dockerfile: "Dockerfile",
+		ContextDir: tmpDir,
+	})
+
+	if r.Container.Config.Image != imageRef {
+		t.Fatalf("container image = %q, want %q", r.Container.Config.Image, imageRef)
+	}
+
+	r.CloseT(t)
+}
+
+func TestRunUsesLocalImageWithoutPull(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	pool := dockertest.NewPoolT(t, "")
+	tmpDir := t.TempDir()
+
+	dockerfile := `FROM alpine:latest
+CMD ["sleep", "300"]
+`
+	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
+	if err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o644); err != nil {
+		t.Fatalf("Failed to write Dockerfile: %v", err)
+	}
+
+	// If Run attempts a pull, this registry will fail DNS resolution.
+	repository := "example.invalid/dockertest-local-skip-pull"
+
+	first := pool.BuildAndRunT(t, repository, &dockertest.BuildOptions{
+		Dockerfile: "Dockerfile",
+		ContextDir: tmpDir,
+	}, dockertest.WithoutReuse())
+	first.CloseT(t)
+
+	second := pool.RunT(t, repository,
+		dockertest.WithTag("latest"),
+		dockertest.WithoutReuse(),
+	)
+	second.CloseT(t)
+}

--- a/network.go
+++ b/network.go
@@ -5,6 +5,10 @@ package dockertest
 
 import (
 	"context"
+	"fmt"
+	"net/netip"
+	"strings"
+	"time"
 
 	"github.com/moby/moby/api/types/network"
 	mobyclient "github.com/moby/moby/client"
@@ -65,7 +69,10 @@ func (p *Pool) CreateNetwork(ctx context.Context, name string, opts *NetworkCrea
 	// Create the network
 	createResp, err := p.client.NetworkCreate(ctx, name, createOpts)
 	if err != nil {
-		return nil, err
+		createResp, err = p.retryNetworkCreateWithCustomSubnet(ctx, name, createOpts, err)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Inspect the network to get full details
@@ -80,6 +87,50 @@ func (p *Pool) CreateNetwork(ctx context.Context, name string, opts *NetworkCrea
 		pool:    p,
 		Network: inspectResp.Network,
 	}, nil
+}
+
+func (p *Pool) retryNetworkCreateWithCustomSubnet(
+	ctx context.Context,
+	name string,
+	createOpts mobyclient.NetworkCreateOptions,
+	createErr error,
+) (mobyclient.NetworkCreateResult, error) {
+	if createOpts.IPAM != nil || !strings.Contains(createErr.Error(), "all predefined address pools have been fully subnetted") {
+		return mobyclient.NetworkCreateResult{}, createErr
+	}
+
+	seed := time.Now().UnixNano()
+	for i := 0; i < 128; i++ {
+		thirdOctet := (int(seed>>8) + i) % 256
+		secondOctet := 16 + ((int(seed>>16) + i) % 16) // 172.16.0.0/12 private range
+		subnet := fmt.Sprintf("172.%d.%d.0/24", secondOctet, thirdOctet)
+		prefix, err := netip.ParsePrefix(subnet)
+		if err != nil {
+			continue
+		}
+
+		retryOpts := createOpts
+		retryOpts.IPAM = &network.IPAM{
+			Driver: "default",
+			Config: []network.IPAMConfig{
+				{Subnet: prefix},
+			},
+		}
+
+		createResp, err := p.client.NetworkCreate(ctx, name, retryOpts)
+		if err == nil {
+			return createResp, nil
+		}
+
+		if strings.Contains(err.Error(), "Pool overlaps with other one on this address space") ||
+			strings.Contains(err.Error(), "all predefined address pools have been fully subnetted") {
+			continue
+		}
+
+		return mobyclient.NetworkCreateResult{}, err
+	}
+
+	return mobyclient.NetworkCreateResult{}, createErr
 }
 
 // CreateNetworkT creates a network using t.Context() and calls t.Fatalf on error.
@@ -109,7 +160,7 @@ func (n *Network) Close(ctx context.Context) error {
 // CloseT removes the network and calls t.Fatalf on error.
 func (n *Network) CloseT(t TestingTB) {
 	t.Helper()
-	if err := n.Close(t.Context()); err != nil {
+	if err := n.Close(context.WithoutCancel(t.Context())); err != nil {
 		t.Fatalf("CloseT failed: %v", err)
 	}
 }

--- a/network_test.go
+++ b/network_test.go
@@ -4,16 +4,23 @@
 package dockertest_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	dockertest "github.com/ory/dockertest/v4"
 )
 
+func uniqueNetworkName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
 func TestPoolCreateNetwork(t *testing.T) {
 	t.Run("creates network with name", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
+		name := uniqueNetworkName("test-network")
 
-		network, err := pool.CreateNetwork(t.Context(), "test-network", nil)
+		network, err := pool.CreateNetwork(t.Context(), name, nil)
 		if err != nil {
 			t.Fatalf("CreateNetwork() error = %v, want nil", err)
 		}
@@ -24,8 +31,8 @@ func TestPoolCreateNetwork(t *testing.T) {
 			network.Close(t.Context())
 		})
 
-		if network.Network.Name != "test-network" {
-			t.Errorf("network.Network.Name = %q, want %q", network.Network.Name, "test-network")
+		if network.Network.Name != name {
+			t.Errorf("network.Network.Name = %q, want %q", network.Network.Name, name)
 		}
 		if network.Network.ID == "" {
 			t.Error("network.Network.ID is empty, want non-empty")
@@ -41,8 +48,9 @@ func TestPoolCreateNetwork(t *testing.T) {
 				"test": "label",
 			},
 		}
+		name := uniqueNetworkName("test-network-opts")
 
-		network, err := pool.CreateNetwork(t.Context(), "test-network-opts", &opts)
+		network, err := pool.CreateNetwork(t.Context(), name, &opts)
 		if err != nil {
 			t.Fatalf("CreateNetwork() error = %v, want nil", err)
 		}
@@ -60,8 +68,9 @@ func TestPoolCreateNetwork(t *testing.T) {
 
 	t.Run("creates network with nil options", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
+		name := uniqueNetworkName("test-network-nil")
 
-		network, err := pool.CreateNetwork(t.Context(), "test-network-nil", nil)
+		network, err := pool.CreateNetwork(t.Context(), name, nil)
 		if err != nil {
 			t.Fatalf("CreateNetwork() error = %v, want nil", err)
 		}
@@ -69,8 +78,8 @@ func TestPoolCreateNetwork(t *testing.T) {
 			network.Close(t.Context())
 		})
 
-		if network.Network.Name != "test-network-nil" {
-			t.Errorf("network.Network.Name = %q, want %q", network.Network.Name, "test-network-nil")
+		if network.Network.Name != name {
+			t.Errorf("network.Network.Name = %q, want %q", network.Network.Name, name)
 		}
 	})
 }
@@ -78,8 +87,9 @@ func TestPoolCreateNetwork(t *testing.T) {
 func TestPoolCreateNetworkT(t *testing.T) {
 	t.Run("creates network using t.Context", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
+		name := uniqueNetworkName("test-network-t")
 
-		network := pool.CreateNetworkT(t, "test-network-t", nil)
+		network := pool.CreateNetworkT(t, name, nil)
 		if network == nil {
 			t.Fatal("CreateNetworkT() network = nil, want non-nil")
 		}
@@ -87,8 +97,8 @@ func TestPoolCreateNetworkT(t *testing.T) {
 			network.Close(t.Context())
 		})
 
-		if network.Network.Name != "test-network-t" {
-			t.Errorf("network.Network.Name = %q, want %q", network.Network.Name, "test-network-t")
+		if network.Network.Name != name {
+			t.Errorf("network.Network.Name = %q, want %q", network.Network.Name, name)
 		}
 	})
 }
@@ -96,8 +106,7 @@ func TestPoolCreateNetworkT(t *testing.T) {
 func TestNetworkClose(t *testing.T) {
 	t.Run("removes network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
-		// Use a unique name based on current time to avoid conflicts
-		networkName := "test-network-close-" + t.Name()
+		networkName := uniqueNetworkName("test-network-close")
 		network := pool.CreateNetworkT(t, networkName, nil)
 
 		err := network.Close(t.Context())
@@ -119,7 +128,7 @@ func TestNetworkClose(t *testing.T) {
 func TestNetworkCloseT(t *testing.T) {
 	t.Run("removes network using t.Context", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
-		network := pool.CreateNetworkT(t, "test-network-closet", nil)
+		network := pool.CreateNetworkT(t, uniqueNetworkName("test-network-closet"), nil)
 
 		network.CloseT(t)
 
@@ -130,7 +139,7 @@ func TestNetworkCloseT(t *testing.T) {
 func TestResourceConnectToNetwork(t *testing.T) {
 	t.Run("connects container to network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
-		network := pool.CreateNetworkT(t, "test-connect-network", nil)
+		network := pool.CreateNetworkT(t, uniqueNetworkName("test-connect-network"), nil)
 		t.Cleanup(func() {
 			network.Close(t.Context())
 		})
@@ -156,7 +165,7 @@ func TestResourceConnectToNetwork(t *testing.T) {
 func TestResourceDisconnectFromNetwork(t *testing.T) {
 	t.Run("disconnects container from network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
-		network := pool.CreateNetworkT(t, "test-disconnect-network", nil)
+		network := pool.CreateNetworkT(t, uniqueNetworkName("test-disconnect-network"), nil)
 		t.Cleanup(func() {
 			network.Close(t.Context())
 		})
@@ -195,7 +204,7 @@ func TestResourceDisconnectFromNetwork(t *testing.T) {
 func TestResourceGetIPInNetwork(t *testing.T) {
 	t.Run("returns IP in network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
-		network := pool.CreateNetworkT(t, "test-getip-network", nil)
+		network := pool.CreateNetworkT(t, uniqueNetworkName("test-getip-network"), nil)
 		t.Cleanup(func() {
 			network.Close(t.Context())
 		})
@@ -223,7 +232,7 @@ func TestResourceGetIPInNetwork(t *testing.T) {
 
 	t.Run("returns empty for non-connected network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
-		network := pool.CreateNetworkT(t, "test-noip-network", nil)
+		network := pool.CreateNetworkT(t, uniqueNetworkName("test-noip-network"), nil)
 		t.Cleanup(func() {
 			network.Close(t.Context())
 		})
@@ -246,7 +255,7 @@ func TestNetworkIntegration(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
 
 		// Create custom network
-		network := pool.CreateNetworkT(t, "test-integration-network", nil)
+		network := pool.CreateNetworkT(t, uniqueNetworkName("test-integration-network"), nil)
 		t.Cleanup(func() {
 			network.Close(t.Context())
 		})

--- a/pool.go
+++ b/pool.go
@@ -7,9 +7,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
 	mobyclient "github.com/moby/moby/client"
 	"github.com/ory/dockertest/v4/internal/client"
@@ -35,6 +38,8 @@ type Pool struct {
 	client      client.DockerClient
 	ownedClient bool          // true if Pool created the client and should close it
 	MaxWait     time.Duration // maximum wait time for operations
+	reuseScope  string
+	resources   sync.Map
 }
 
 // NewPool creates a new Pool with the given endpoint and options.
@@ -85,7 +90,49 @@ func NewPool(ctx context.Context, endpoint string, opts ...PoolOption) (*Pool, e
 		p.ownedClient = true
 	}
 
+	p.reuseScope = clientScope(p.client)
+
 	return p, nil
+}
+
+func clientScope(c client.DockerClient) string {
+	if c == nil {
+		return "nil-client"
+	}
+
+	v := reflect.ValueOf(c)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.UnsafePointer, reflect.Map, reflect.Chan, reflect.Func, reflect.Slice:
+		return fmt.Sprintf("%T:%x", c, v.Pointer())
+	default:
+		return fmt.Sprintf("%T:%v", c, c)
+	}
+}
+
+func (p *Pool) trackResource(resource *Resource) {
+	if resource == nil || resource.Container.ID == "" {
+		return
+	}
+	p.resources.Store(resource.Container.ID, resource)
+}
+
+func (p *Pool) untrackResource(containerID string) {
+	if containerID == "" {
+		return
+	}
+	p.resources.Delete(containerID)
+}
+
+func (p *Pool) trackedResources() []*Resource {
+	var resources []*Resource
+	p.resources.Range(func(_, value any) bool {
+		resource, ok := value.(*Resource)
+		if ok {
+			resources = append(resources, resource)
+		}
+		return true
+	})
+	return resources
 }
 
 // NewPoolT creates a new Pool using t.Context() and registers cleanup with t.Cleanup().
@@ -118,21 +165,24 @@ func (p *Pool) Close() error {
 	return nil
 }
 
-// Cleanup removes all containers in the global registry.
+// Cleanup removes all containers tracked by this pool.
 // Errors during cleanup do not stop the cleanup process.
 // The first error encountered is returned.
 func (p *Pool) Cleanup(ctx context.Context) error {
-	resources := GetAll()
+	cleanupCtx := context.WithoutCancel(ctx)
+	resources := p.trackedResources()
 
 	var firstErr error
 	for _, resource := range resources {
-		if err := resource.Close(ctx); err != nil && firstErr == nil {
+		if err := resource.Close(cleanupCtx); err != nil && firstErr == nil {
 			firstErr = err
 		}
+		p.untrackResource(resource.Container.ID)
 	}
 
-	// Clear the registry after cleanup
-	ResetRegistry()
+	if p.reuseScope != "" {
+		resetRegistryWithScope(p.reuseScope)
+	}
 
 	return firstErr
 }
@@ -158,7 +208,8 @@ func (p *Pool) Run(ctx context.Context, repository string, opts ...RunOption) (*
 
 	reuseID := computeReuseID(repository, cfg)
 
-	if existing := checkForExisting(reuseID); existing != nil {
+	if existing := checkForExisting(p, reuseID); existing != nil {
+		p.trackResource(existing)
 		return existing, nil
 	}
 
@@ -201,12 +252,14 @@ func computeReuseID(repository string, cfg *runConfig) string {
 }
 
 // checkForExisting looks up an existing container in the registry.
-func checkForExisting(reuseID string) *Resource {
+func checkForExisting(p *Pool, reuseID string) *Resource {
 	if reuseID == "" {
 		return nil
 	}
-	if existing, ok := Get(reuseID); ok {
-		return existing
+	if existing, ok := getWithScope(p.reuseScope, reuseID); ok {
+		cloned := *existing
+		cloned.pool = p
+		return &cloned
 	}
 	return nil
 }
@@ -215,6 +268,12 @@ func checkForExisting(reuseID string) *Resource {
 func (p *Pool) pullImage(ctx context.Context, ref string, noPull bool) error {
 	if noPull {
 		return nil
+	}
+
+	if _, err := p.client.ImageInspect(ctx, ref); err == nil {
+		return nil
+	} else if !errdefs.IsNotFound(err) {
+		return fmt.Errorf("image inspect failed for %s: %w", ref, err)
 	}
 
 	pullResp, err := p.client.ImagePull(ctx, ref, mobyclient.ImagePullOptions{})
@@ -285,13 +344,27 @@ func (p *Pool) inspectAndRegister(ctx context.Context, containerID, reuseID stri
 	resource := &Resource{
 		pool:      p,
 		Container: inspectResp.Container,
+		reuseID:   reuseID,
 	}
 
 	if reuseID != "" {
-		if err := Register(reuseID, resource); err != nil {
-			return nil, err
+		canonical, loaded := registerWithScope(p.reuseScope, reuseID, resource)
+		if loaded {
+			cleanupCtx := context.WithoutCancel(ctx)
+			_, _ = p.client.ContainerRemove(cleanupCtx, containerID, mobyclient.ContainerRemoveOptions{
+				Force:         true,
+				RemoveVolumes: true,
+			}) //nolint:errcheck // Best effort cleanup of duplicate container
+
+			cloned := *canonical
+			cloned.pool = p
+			resource = &cloned
+		} else {
+			resource = canonical
 		}
 	}
+
+	p.trackResource(resource)
 
 	return resource, nil
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/api/types/container"
 	mobyclient "github.com/moby/moby/client"
 	"github.com/ory/dockertest/v4/internal/client"
 )
@@ -175,4 +177,48 @@ func TestPoolCleanup(t *testing.T) {
 			t.Errorf("Cleanup() error = %v, want nil", err)
 		}
 	})
+}
+
+func TestCheckForExistingUsesPoolScope(t *testing.T) {
+	ResetRegistry()
+
+	resource := &Resource{Container: container.InspectResponse{ID: "scoped-container"}}
+	_, _ = registerWithScope("scope-a", "reuse-id", resource)
+
+	poolA := &Pool{reuseScope: "scope-a"}
+	if got := checkForExisting(poolA, "reuse-id"); got == nil || got.ID() != "scoped-container" {
+		t.Fatalf("checkForExisting(scope-a) = %#v, want container scoped-container", got)
+	}
+
+	poolB := &Pool{reuseScope: "scope-b"}
+	if got := checkForExisting(poolB, "reuse-id"); got != nil {
+		t.Fatalf("checkForExisting(scope-b) = %#v, want nil", got)
+	}
+}
+
+func TestPoolCleanupRemovesWithoutReuse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ResetRegistry()
+	t.Cleanup(func() {
+		ResetRegistry()
+	})
+
+	pool := NewPoolT(t, "")
+	resource := pool.RunT(t, "alpine",
+		WithTag("latest"),
+		WithCmd([]string{"sleep", "300"}),
+		WithoutReuse(),
+	)
+
+	if err := pool.Cleanup(t.Context()); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	_, err := pool.client.ContainerInspect(t.Context(), resource.ID(), mobyclient.ContainerInspectOptions{})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("ContainerInspect() error = %v, want not found", err)
+	}
 }

--- a/registry.go
+++ b/registry.go
@@ -15,12 +15,20 @@ import (
 type Resource struct {
 	pool      *Pool
 	Container container.InspectResponse
+	reuseID   string
 }
 
 // ID returns the container ID.
 func (r *Resource) ID() string {
 	return r.Container.ID
 }
+
+type registryKey struct {
+	scope   string
+	reuseID string
+}
+
+const defaultRegistryScope = "default"
 
 // globalRegistry is the package-level container registry using sync.Map for thread-safety.
 var globalRegistry sync.Map
@@ -39,9 +47,7 @@ var globalRegistry sync.Map
 // Note: This function is called automatically by Pool.Run when container reuse
 // is enabled. You typically don't need to call it directly.
 func Register(reuseID string, r *Resource) error {
-	// LoadOrStore is atomic; race conditions are safe because competing
-	// resources have identical configurations.
-	globalRegistry.LoadOrStore(reuseID, r)
+	_, _ = registerWithScope(defaultRegistryScope, reuseID, r)
 	return nil
 }
 
@@ -54,15 +60,7 @@ func Register(reuseID string, r *Resource) error {
 // Note: This function is called automatically by Pool.Run when checking for
 // existing containers. You typically don't need to call it directly.
 func Get(reuseID string) (*Resource, bool) {
-	val, ok := globalRegistry.Load(reuseID)
-	if !ok {
-		return nil, false
-	}
-	resource, ok := val.(*Resource)
-	if !ok {
-		return nil, false
-	}
-	return resource, true
+	return getWithScope(defaultRegistryScope, reuseID)
 }
 
 // GetAll returns a slice of all resources in the global registry.
@@ -77,9 +75,43 @@ func Get(reuseID string) (*Resource, bool) {
 //		dockertest.ResetRegistry()
 //	}
 func GetAll() []*Resource {
+	return getAllWithScope(defaultRegistryScope)
+}
+
+func registerWithScope(scope, reuseID string, r *Resource) (*Resource, bool) {
+	key := registryKey{scope: scope, reuseID: reuseID}
+	actual, loaded := globalRegistry.LoadOrStore(key, r)
+	resource, ok := actual.(*Resource)
+	if !ok {
+		return r, loaded
+	}
+	return resource, loaded
+}
+
+func unregisterWithScope(scope, reuseID string) {
+	globalRegistry.Delete(registryKey{scope: scope, reuseID: reuseID})
+}
+
+func getWithScope(scope, reuseID string) (*Resource, bool) {
+	val, ok := globalRegistry.Load(registryKey{scope: scope, reuseID: reuseID})
+	if !ok {
+		return nil, false
+	}
+	resource, ok := val.(*Resource)
+	if !ok {
+		return nil, false
+	}
+	return resource, true
+}
+
+func getAllWithScope(scope string) []*Resource {
 	var resources []*Resource
 
-	globalRegistry.Range(func(_, value any) bool {
+	globalRegistry.Range(func(key, value any) bool {
+		regKey, ok := key.(registryKey)
+		if !ok || regKey.scope != scope {
+			return true
+		}
 		if resource, ok := value.(*Resource); ok {
 			resources = append(resources, resource)
 		}
@@ -87,6 +119,21 @@ func GetAll() []*Resource {
 	})
 
 	return resources
+}
+
+func resetRegistryWithScope(scope string) {
+	var keys []registryKey
+	globalRegistry.Range(func(key, _ any) bool {
+		regKey, ok := key.(registryKey)
+		if ok && regKey.scope == scope {
+			keys = append(keys, regKey)
+		}
+		return true
+	})
+
+	for _, key := range keys {
+		globalRegistry.Delete(key)
+	}
 }
 
 // ResetRegistry clears all resources from the global registry.

--- a/registry_test.go
+++ b/registry_test.go
@@ -162,3 +162,60 @@ func TestRegistryConcurrency(t *testing.T) {
 		t.Errorf("GetAll() length = %v, want 1 (only first registration should succeed)", len(all))
 	}
 }
+
+func TestRegistryScopes(t *testing.T) {
+	ResetRegistry()
+
+	r1 := &Resource{Container: container.InspectResponse{ID: "scope-a-container"}}
+	r2 := &Resource{Container: container.InspectResponse{ID: "scope-b-container"}}
+
+	_, loadedA := registerWithScope("scope-a", "same-reuse-id", r1)
+	if loadedA {
+		t.Fatal("registerWithScope(scope-a) loaded = true, want false")
+	}
+	_, loadedB := registerWithScope("scope-b", "same-reuse-id", r2)
+	if loadedB {
+		t.Fatal("registerWithScope(scope-b) loaded = true, want false")
+	}
+
+	gotA, okA := getWithScope("scope-a", "same-reuse-id")
+	if !okA || gotA.ID() != "scope-a-container" {
+		t.Fatalf("scope-a lookup failed: ok=%v id=%v", okA, gotA)
+	}
+
+	gotB, okB := getWithScope("scope-b", "same-reuse-id")
+	if !okB || gotB.ID() != "scope-b-container" {
+		t.Fatalf("scope-b lookup failed: ok=%v id=%v", okB, gotB)
+	}
+
+	resetRegistryWithScope("scope-a")
+	if _, ok := getWithScope("scope-a", "same-reuse-id"); ok {
+		t.Fatal("scope-a entry still present after resetRegistryWithScope")
+	}
+	if _, ok := getWithScope("scope-b", "same-reuse-id"); !ok {
+		t.Fatal("scope-b entry unexpectedly removed by scope-a reset")
+	}
+}
+
+func TestRegisterWithScopeLoadOrStore(t *testing.T) {
+	ResetRegistry()
+
+	first := &Resource{Container: container.InspectResponse{ID: "first"}}
+	second := &Resource{Container: container.InspectResponse{ID: "second"}}
+
+	stored, loaded := registerWithScope("scope", "reuse", first)
+	if loaded {
+		t.Fatal("first registerWithScope call loaded = true, want false")
+	}
+	if stored.ID() != first.ID() {
+		t.Fatalf("first stored resource = %q, want %q", stored.ID(), first.ID())
+	}
+
+	stored, loaded = registerWithScope("scope", "reuse", second)
+	if !loaded {
+		t.Fatal("second registerWithScope call loaded = false, want true")
+	}
+	if stored.ID() != first.ID() {
+		t.Fatalf("second stored resource = %q, want %q", stored.ID(), first.ID())
+	}
+}

--- a/resource.go
+++ b/resource.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 
 	"github.com/moby/moby/api/types/network"
 	mobyclient "github.com/moby/moby/client"
@@ -50,7 +51,12 @@ func (r *Resource) GetBoundIP(portID string) string {
 		return ""
 	}
 
-	return bindings[0].HostIP.String()
+	ip := bindings[0].HostIP.String()
+	if ip == "" || ip == "0.0.0.0" || ip == "::" {
+		return "localhost"
+	}
+
+	return ip
 }
 
 // GetHostPort returns the host:port combination for the given container port.
@@ -63,7 +69,7 @@ func (r *Resource) GetHostPort(portID string) string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s:%s", ip, port)
+	return net.JoinHostPort(ip, port)
 }
 
 // Close stops and removes the container.
@@ -81,13 +87,22 @@ func (r *Resource) Close(ctx context.Context) error {
 		RemoveVolumes: true,
 		Force:         true,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	if r.reuseID != "" {
+		unregisterWithScope(r.pool.reuseScope, r.reuseID)
+	}
+	r.pool.untrackResource(r.Container.ID)
+
+	return nil
 }
 
 // CloseT stops and removes the container and calls t.Fatalf on error.
 func (r *Resource) CloseT(t TestingTB) {
 	t.Helper()
-	if err := r.Close(t.Context()); err != nil {
+	if err := r.Close(context.WithoutCancel(t.Context())); err != nil {
 		t.Fatalf("CloseT failed: %v", err)
 	}
 }

--- a/resource_test.go
+++ b/resource_test.go
@@ -79,6 +79,23 @@ func TestResourceGetBoundIP(t *testing.T) {
 	}
 }
 
+func TestResourceGetBoundIPLocalhostFallback(t *testing.T) {
+	r := &dockertest.Resource{
+		Container: container.InspectResponse{
+			NetworkSettings: &container.NetworkSettings{
+				Ports: network.PortMap{
+					network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: "54320"}},
+				},
+			},
+		},
+	}
+
+	ip := r.GetBoundIP("5432/tcp")
+	if ip != "localhost" {
+		t.Errorf("GetBoundIP() = %q, want %q", ip, "localhost")
+	}
+}
+
 func TestResourceGetHostPort(t *testing.T) {
 	r := &dockertest.Resource{
 		Container: container.InspectResponse{
@@ -108,5 +125,22 @@ func TestResourceGetHostPort(t *testing.T) {
 	hostPort = rNil.GetHostPort("5432/tcp")
 	if hostPort != "" {
 		t.Errorf("GetHostPort(nil NetworkSettings) = %q, want empty string", hostPort)
+	}
+}
+
+func TestResourceGetHostPortIPv6(t *testing.T) {
+	r := &dockertest.Resource{
+		Container: container.InspectResponse{
+			NetworkSettings: &container.NetworkSettings{
+				Ports: network.PortMap{
+					network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("::1"), HostPort: "54320"}},
+				},
+			},
+		},
+	}
+
+	hostPort := r.GetHostPort("5432/tcp")
+	if hostPort != "[::1]:54320" {
+		t.Errorf("GetHostPort() = %q, want %q", hostPort, "[::1]:54320")
 	}
 }


### PR DESCRIPTION
## Related Issue or Design Document

This fixes regressions introduced by the v4 refactor and verified in branch review (tagged `BuildAndRun`, cleanup context cancellation, non-reuse cleanup gaps, global reuse leakage, and duplicate-container races). It also restores host/port behavior, improves network creation resilience under exhausted address pools, and updates tests and migration docs accordingly.

## Checklist

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.com](mailto:security@ory.com)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Includes targeted unit/integration coverage for all fixed regressions and passes `go test ./...`.
