### PR TITLE
fix: v4 regressions - comprehensive fixes across core components

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ func TestMain(m *testing.M) {
     ctx := context.Background()
     pool, _ := dockertest.NewPool(ctx, "")
     code := m.Run()
-    defer pool.Cleanup(ctx)
+    // Clean up before os.Exit — deferred functions do not run after os.Exit.
+    pool.Cleanup(ctx)
+    pool.Close()
     os.Exit(code)
 }
 ```
@@ -184,8 +186,10 @@ Available configuration options:
 - `WithEnv(env []string)` - Set environment variables
 - `WithCmd(cmd []string)` - Override the default command
 - `WithEntrypoint(entrypoint []string)` - Override the default entrypoint
+- `WithHostConfig(modifier func(*container.HostConfig))` - Modify the host
+  config (port bindings, volumes, restart policy, memory/CPU limits)
 
-For advanced configuration, use `WithContainerConfig`:
+For advanced container configuration, use `WithContainerConfig`:
 
 ```go
 stopTimeout := 30
@@ -203,7 +207,28 @@ resource := pool.RunT(t, "app",
 )
 ```
 
+For host-level configuration, use `WithHostConfig`:
+
+```go
+resource := pool.RunT(t, "postgres",
+    dockertest.WithTag("14"),
+    dockertest.WithHostConfig(func(hc *container.HostConfig) {
+        hc.RestartPolicy = container.RestartPolicy{
+            Name:              container.RestartPolicyOnFailure,
+            MaximumRetryCount: 3,
+        }
+    }),
+)
+```
+
 ### Container reuse
+
+> [!WARNING]
+>
+> Do not use `resource.Cleanup(t)` on reused containers. Because reused
+> containers are shared across tests, cleaning up one reference will remove the
+> container for all other tests that depend on it. Only use `pool.Cleanup(ctx)`
+> in `TestMain` to clean up reused containers after all tests have finished.
 
 Containers are automatically reused based on `repository:tag`:
 
@@ -242,6 +267,21 @@ ip := resource.GetBoundIP("5432/tcp")
 
 // Get container ID
 id := resource.ID()
+```
+
+### Executing commands
+
+Run commands inside a running container:
+
+```go
+result, err := resource.Exec(ctx, []string{"pg_isready", "-U", "postgres"})
+if err != nil {
+    t.Fatal(err)
+}
+if result.ExitCode != 0 {
+    t.Fatalf("command failed: %s", result.StdErr)
+}
+t.Log(result.StdOut)
 ```
 
 ### Cleanup

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,14 +32,16 @@ intended due to Docker API limitations.
 **Workarounds for container cleanup in CI:**
 
 - Use `pool.Cleanup(ctx)` in `TestMain` to remove all containers after tests.
-- Run `docker container prune -f` as a CI post-step to remove stopped containers.
+- Run `docker container prune -f` as a CI post-step to remove stopped
+  containers.
 - Use `WithLabels` to tag test containers for targeted cleanup:
   ```go
   resource := pool.RunT(t, "postgres",
       dockertest.WithLabels(map[string]string{"ci-run": os.Getenv("CI_RUN_ID")}),
   )
   ```
-  Then in CI: `docker container rm $(docker container ls -q --filter label=ci-run=$CI_RUN_ID)`
+  Then in CI:
+  `docker container rm $(docker container ls -q --filter label=ci-run=$CI_RUN_ID)`
 
 ### Import Path
 
@@ -239,9 +241,9 @@ cache.Cleanup(t)
 > container for all other tests that depend on it. Only use `pool.Cleanup(ctx)`
 > in `TestMain` to clean up reused containers after all tests have finished.
 
-v4 automatically reuses containers with the same `repo:tag` across tests.
-Each `NewPoolT` call creates a separate pool, but containers are still shared
-because default pools use a common reuse scope:
+v4 automatically reuses containers with the same `repo:tag` across tests. Each
+`NewPoolT` call creates a separate pool, but containers are still shared because
+default pools use a common reuse scope:
 
 ```go
 func TestUser(t *testing.T) {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,6 +29,18 @@ This guide helps you migrate from dockertest v3 to v4.
 The `Expire` method from v3 is removed as it was not working as documented /
 intended due to Docker API limitations.
 
+**Workarounds for container cleanup in CI:**
+
+- Use `pool.Cleanup(ctx)` in `TestMain` to remove all containers after tests.
+- Run `docker container prune -f` as a CI post-step to remove stopped containers.
+- Use `WithLabels` to tag test containers for targeted cleanup:
+  ```go
+  resource := pool.RunT(t, "postgres",
+      dockertest.WithLabels(map[string]string{"ci-run": os.Getenv("CI_RUN_ID")}),
+  )
+  ```
+  Then in CI: `docker container rm $(docker container ls -q --filter label=ci-run=$CI_RUN_ID)`
+
 ### Import Path
 
 ```diff
@@ -111,12 +123,14 @@ func TestMain(m *testing.M) {
     os.Exit(code)
 }
 
-// v4 - TestMain with automatic cleanup
+// v4 - TestMain with cleanup
 func TestMain(m *testing.M) {
     ctx := context.Background()
     pool, _ := dockertest.NewPool(ctx, "")
     code := m.Run()
-    defer pool.Cleanup(ctx)
+    // Clean up before os.Exit — deferred functions do not run after os.Exit.
+    pool.Cleanup(ctx)
+    pool.Close()
     os.Exit(code)
 }
 ```
@@ -157,7 +171,9 @@ if errors.Is(err, context.DeadlineExceeded) {
        ctx := context.Background()
        pool, _ := dockertest.NewPool(ctx, "")
        code := m.Run()
-       defer pool.Cleanup(ctx)
+       // Clean up before os.Exit — deferred functions do not run after os.Exit.
+       pool.Cleanup(ctx)
+       pool.Close()
        os.Exit(code)
    }
    ```
@@ -216,12 +232,21 @@ cache.Cleanup(t)
 
 ### Automatic Container Reuse
 
-v4 automatically reuses containers with the same `repo:tag` across tests:
+> [!WARNING]
+>
+> Do not use `resource.Cleanup(t)` on reused containers. Because reused
+> containers are shared across tests, cleaning up one reference will remove the
+> container for all other tests that depend on it. Only use `pool.Cleanup(ctx)`
+> in `TestMain` to clean up reused containers after all tests have finished.
+
+v4 automatically reuses containers with the same `repo:tag` across tests.
+Each `NewPoolT` call creates a separate pool, but containers are still shared
+because default pools use a common reuse scope:
 
 ```go
 func TestUser(t *testing.T) {
     pool := dockertest.NewPoolT(t, "")
-    db := pool.RunT(t, "postgres", dockertest.WithTag("14")) // First call
+    db := pool.RunT(t, "postgres", dockertest.WithTag("14")) // Creates container
 }
 
 func TestPost(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -13,3 +13,7 @@ var ErrContainerCreateFailed = errors.New("container creation failed")
 
 // ErrContainerStartFailed is returned when starting a container fails.
 var ErrContainerStartFailed = errors.New("container start failed")
+
+// ErrClientClosed is returned when an operation is attempted on a resource
+// whose pool or client has already been closed.
+var ErrClientClosed = errors.New("client is closed")

--- a/network.go
+++ b/network.go
@@ -157,7 +157,7 @@ func (p *Pool) CreateNetworkT(t TestingTB, name string, opts *NetworkCreateOptio
 // or the network removal will fail.
 func (n *Network) Close(ctx context.Context) error {
 	if n.pool == nil || n.pool.client == nil {
-		return nil
+		return ErrClientClosed
 	}
 
 	_, err := n.pool.client.NetworkRemove(ctx, n.Network.ID, mobyclient.NetworkRemoveOptions{})
@@ -182,7 +182,7 @@ func (n *Network) CloseT(t TestingTB) {
 // network settings after connection.
 func (r *Resource) ConnectToNetwork(ctx context.Context, net *Network) error {
 	if r.pool == nil || r.pool.client == nil {
-		return fmt.Errorf("pool or client is nil")
+		return ErrClientClosed
 	}
 
 	connectOpts := mobyclient.NetworkConnectOptions{
@@ -209,7 +209,7 @@ func (r *Resource) ConnectToNetwork(ctx context.Context, net *Network) error {
 // network settings after disconnection.
 func (r *Resource) DisconnectFromNetwork(ctx context.Context, net *Network) error {
 	if r.pool == nil || r.pool.client == nil {
-		return fmt.Errorf("pool or client is nil")
+		return ErrClientClosed
 	}
 
 	disconnectOpts := mobyclient.NetworkDisconnectOptions{

--- a/options.go
+++ b/options.go
@@ -39,19 +39,19 @@ type RunOption func(*runConfig) error
 //
 //nolint:govet // field alignment traded for readability
 type runConfig struct {
-	env            []string
-	cmd            []string
-	entrypoint     []string
-	tag            string
-	reuseID        string
-	user           string
-	workingDir     string
-	hostname       string
-	labels         map[string]string
+	env                []string
+	cmd                []string
+	entrypoint         []string
+	tag                string
+	reuseID            string
+	user               string
+	workingDir         string
+	hostname           string
+	labels             map[string]string
 	configModifier     func(*container.Config)
 	hostConfigModifier func(*container.HostConfig)
 	noReuse            bool
-	noPull         bool // skip image pull (for locally built images)
+	noPull             bool // skip image pull (for locally built images)
 }
 
 // WithTag sets the image tag. Default is "latest".

--- a/options.go
+++ b/options.go
@@ -48,8 +48,9 @@ type runConfig struct {
 	workingDir     string
 	hostname       string
 	labels         map[string]string
-	configModifier func(*container.Config)
-	noReuse        bool
+	configModifier     func(*container.Config)
+	hostConfigModifier func(*container.HostConfig)
+	noReuse            bool
 	noPull         bool // skip image pull (for locally built images)
 }
 
@@ -144,6 +145,17 @@ func WithHostname(hostname string) RunOption {
 func WithContainerConfig(modifier func(*container.Config)) RunOption {
 	return func(rc *runConfig) error {
 		rc.configModifier = modifier
+		return nil
+	}
+}
+
+// WithHostConfig allows direct modification of the container.HostConfig.
+// Use this to set host-level options like port bindings, volume mounts,
+// restart policies, memory/CPU limits, or AutoRemove.
+// The modifier is applied after the default HostConfig is constructed.
+func WithHostConfig(modifier func(*container.HostConfig)) RunOption {
+	return func(rc *runConfig) error {
+		rc.hostConfigModifier = modifier
 		return nil
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dockertest",
+  "name": "gwangju",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "gwangju",
+  "name": "dockertest",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/pool.go
+++ b/pool.go
@@ -90,16 +90,13 @@ func NewPool(ctx context.Context, endpoint string, opts ...PoolOption) (*Pool, e
 		p.ownedClient = true
 	}
 
-	p.reuseScope = clientScope(p.client)
+	if p.ownedClient {
+		p.reuseScope = defaultRegistryScope
+	} else {
+		p.reuseScope = fmt.Sprintf("%p", p.client)
+	}
 
 	return p, nil
-}
-
-func clientScope(c client.DockerClient) string {
-	if c == nil {
-		return "nil-client"
-	}
-	return fmt.Sprintf("%p", c)
 }
 
 func (p *Pool) trackResource(resource *Resource) {
@@ -164,8 +161,12 @@ func NewPoolT(t *testing.T, endpoint string, opts ...PoolOption) *Pool {
 	}
 
 	t.Cleanup(func() {
+		ctx := context.WithoutCancel(t.Context())
+		if err := pool.Cleanup(ctx); err != nil {
+			t.Logf("pool.Cleanup() error: %v", err)
+		}
 		if err := pool.Close(); err != nil {
-			t.Errorf("pool.Close() error = %v", err)
+			t.Logf("pool.Close() error: %v", err)
 		}
 	})
 
@@ -347,11 +348,18 @@ func (p *Pool) createAndStartContainer(ctx context.Context, ref string, cfg *run
 		cfg.configModifier(containerConfig)
 	}
 
+	hostConfig := &container.HostConfig{
+		PublishAllPorts: true,
+	}
+
+	// Apply host config modifier last to allow overriding anything
+	if cfg.hostConfigModifier != nil {
+		cfg.hostConfigModifier(hostConfig)
+	}
+
 	createOpts := mobyclient.ContainerCreateOptions{
-		Config: containerConfig,
-		HostConfig: &container.HostConfig{
-			PublishAllPorts: true,
-		},
+		Config:     containerConfig,
+		HostConfig: hostConfig,
 	}
 
 	createResp, err := p.client.ContainerCreate(ctx, createOpts)

--- a/pool_test.go
+++ b/pool_test.go
@@ -196,6 +196,54 @@ func TestCheckForExistingUsesPoolScope(t *testing.T) {
 	}
 }
 
+func TestDefaultPoolsShareReuseScope(t *testing.T) {
+	ctx := t.Context()
+	poolA, err := NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("NewPool() error = %v", err)
+	}
+	t.Cleanup(func() { poolA.Close() })
+
+	poolB, err := NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("NewPool() error = %v", err)
+	}
+	t.Cleanup(func() { poolB.Close() })
+
+	if poolA.reuseScope != poolB.reuseScope {
+		t.Fatalf("default pools have different reuse scopes: %q vs %q", poolA.reuseScope, poolB.reuseScope)
+	}
+
+	if poolA.reuseScope != defaultRegistryScope {
+		t.Fatalf("default pool reuse scope = %q, want %q", poolA.reuseScope, defaultRegistryScope)
+	}
+}
+
+func TestCustomClientPoolHasIsolatedScope(t *testing.T) {
+	ctx := t.Context()
+	customClient, err := client.NewMobyClient(ctx)
+	if err != nil {
+		t.Fatalf("NewMobyClient() error = %v", err)
+	}
+	t.Cleanup(func() { customClient.Close() })
+
+	poolCustom, err := NewPool(ctx, "", WithMobyClient(customClient))
+	if err != nil {
+		t.Fatalf("NewPool() error = %v", err)
+	}
+	t.Cleanup(func() { poolCustom.Close() })
+
+	poolDefault, err := NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("NewPool() error = %v", err)
+	}
+	t.Cleanup(func() { poolDefault.Close() })
+
+	if poolCustom.reuseScope == poolDefault.reuseScope {
+		t.Fatal("custom client pool should have isolated reuse scope from default pool")
+	}
+}
+
 func TestPoolCleanupRemovesWithoutReuse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/resource.go
+++ b/resource.go
@@ -13,6 +13,7 @@ import (
 	"net"
 
 	"github.com/containerd/errdefs"
+	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/network"
 	mobyclient "github.com/moby/moby/client"
 )
@@ -77,7 +78,7 @@ func (r *Resource) GetHostPort(portID string) string {
 // Anonymous volumes created by the container are also removed.
 func (r *Resource) Close(ctx context.Context) error {
 	if r.pool == nil || r.pool.client == nil {
-		return nil
+		return ErrClientClosed
 	}
 
 	// Stop container (ignore errors if already stopped)
@@ -123,7 +124,7 @@ func (r *Resource) Cleanup(t TestingTB) {
 // Both stdout and stderr are combined in the returned string.
 func (r *Resource) Logs(ctx context.Context) (string, error) {
 	if r.pool == nil || r.pool.client == nil {
-		return "", fmt.Errorf("pool or client is nil")
+		return "", ErrClientClosed
 	}
 
 	reader, err := r.pool.client.ContainerLogs(ctx, r.Container.ID, mobyclient.ContainerLogsOptions{
@@ -179,4 +180,49 @@ func (r *Resource) Logs(ctx context.Context) (string, error) {
 	}
 
 	return result.String(), nil
+}
+
+// ExecResult holds the output of a command executed inside a container.
+type ExecResult struct {
+	StdOut   string
+	StdErr   string
+	ExitCode int
+}
+
+// Exec runs a command inside the container and returns the result.
+func (r *Resource) Exec(ctx context.Context, cmd []string) (ExecResult, error) {
+	if r.pool == nil || r.pool.client == nil {
+		return ExecResult{}, ErrClientClosed
+	}
+
+	createResp, err := r.pool.client.ExecCreate(ctx, r.Container.ID, mobyclient.ExecCreateOptions{
+		Cmd:          cmd,
+		AttachStdout: true,
+		AttachStderr: true,
+	})
+	if err != nil {
+		return ExecResult{}, fmt.Errorf("exec create failed: %w", err)
+	}
+
+	attachResp, err := r.pool.client.ExecAttach(ctx, createResp.ID, mobyclient.ExecAttachOptions{})
+	if err != nil {
+		return ExecResult{}, fmt.Errorf("exec attach failed: %w", err)
+	}
+	defer attachResp.Conn.Close()
+
+	var stdout, stderr bytes.Buffer
+	if _, err := stdcopy.StdCopy(&stdout, &stderr, attachResp.Reader); err != nil {
+		return ExecResult{}, fmt.Errorf("exec read failed: %w", err)
+	}
+
+	inspectResp, err := r.pool.client.ExecInspect(ctx, createResp.ID, mobyclient.ExecInspectOptions{})
+	if err != nil {
+		return ExecResult{}, fmt.Errorf("exec inspect failed: %w", err)
+	}
+
+	return ExecResult{
+		StdOut:   stdout.String(),
+		StdErr:   stderr.String(),
+		ExitCode: inspectResp.ExitCode,
+	}, nil
 }

--- a/run_test.go
+++ b/run_test.go
@@ -331,3 +331,106 @@ func TestRunWithContainerConfig(t *testing.T) {
 		t.Errorf("expected stop signal 'SIGTERM', got %q", resource.Container.Config.StopSignal)
 	}
 }
+
+func TestRunWithHostConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	pool := dockertest.NewPoolT(t, "")
+
+	resource := pool.RunT(t, "alpine",
+		dockertest.WithTag("latest"),
+		dockertest.WithHostConfig(func(hc *container.HostConfig) {
+			hc.RestartPolicy = container.RestartPolicy{Name: container.RestartPolicyOnFailure, MaximumRetryCount: 3}
+		}),
+		dockertest.WithCmd([]string{"sleep", "10"}),
+		dockertest.WithoutReuse(),
+	)
+	t.Cleanup(func() {
+		resource.CloseT(t)
+	})
+
+	if resource.Container.HostConfig.RestartPolicy.Name != container.RestartPolicyOnFailure {
+		t.Errorf("expected restart policy %q, got %q", container.RestartPolicyOnFailure, resource.Container.HostConfig.RestartPolicy.Name)
+	}
+	if resource.Container.HostConfig.RestartPolicy.MaximumRetryCount != 3 {
+		t.Errorf("expected max retry count 3, got %d", resource.Container.HostConfig.RestartPolicy.MaximumRetryCount)
+	}
+}
+
+func TestResourceExec(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	pool := dockertest.NewPoolT(t, "")
+
+	resource := pool.RunT(t, "alpine",
+		dockertest.WithTag("latest"),
+		dockertest.WithCmd([]string{"sleep", "300"}),
+		dockertest.WithoutReuse(),
+	)
+	t.Cleanup(func() {
+		resource.CloseT(t)
+	})
+
+	result, err := resource.Exec(t.Context(), []string{"echo", "hello world"})
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		t.Errorf("Exec() exit code = %d, want 0", result.ExitCode)
+	}
+	if result.StdOut != "hello world\n" {
+		t.Errorf("Exec() stdout = %q, want %q", result.StdOut, "hello world\n")
+	}
+	if result.StdErr != "" {
+		t.Errorf("Exec() stderr = %q, want empty", result.StdErr)
+	}
+}
+
+func TestResourceExecNonZeroExit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	pool := dockertest.NewPoolT(t, "")
+
+	resource := pool.RunT(t, "alpine",
+		dockertest.WithTag("latest"),
+		dockertest.WithCmd([]string{"sleep", "300"}),
+		dockertest.WithoutReuse(),
+	)
+	t.Cleanup(func() {
+		resource.CloseT(t)
+	})
+
+	result, err := resource.Exec(t.Context(), []string{"sh", "-c", "echo err >&2; exit 1"})
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+
+	if result.ExitCode != 1 {
+		t.Errorf("Exec() exit code = %d, want 1", result.ExitCode)
+	}
+	if result.StdErr != "err\n" {
+		t.Errorf("Exec() stderr = %q, want %q", result.StdErr, "err\n")
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses multiple v4 regressions and improves the API with new functionality:

- Fixed pool reuse scope to use defaultRegistryScope for owned clients
- Added ErrClientClosed error for operations on closed resources
- Implemented WithHostConfig option for host-level container configuration
- Added Resource.Exec method for running commands in containers
- Fixed TestMain cleanup pattern to avoid using defer with os.Exit
- Improved documentation and added comprehensive tests

## Test Plan

- [x] All existing tests pass
- [x] Added tests for host config functionality
- [x] Added tests for exec functionality
- [x] Added tests for pool reuse scope behavior
- [x] Verified error handling with ErrClientClosed

🤖 Generated with [Claude Code](https://claude.com/claude-code)