### PR TITLE
fix: make pool.Close() call cleanup automatically

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -63,7 +63,7 @@ type Pool struct {
 //	if err != nil {
 //		panic(err)
 //	}
-//	defer pool.Close()
+//	defer pool.Close(ctx)
 func NewPool(ctx context.Context, endpoint string, opts ...PoolOption) (*Pool, error) {
 	p := &Pool{
 		MaxWait:     60 * time.Second,
@@ -161,11 +161,7 @@ func NewPoolT(t *testing.T, endpoint string, opts ...PoolOption) *Pool {
 	}
 
 	t.Cleanup(func() {
-		ctx := context.WithoutCancel(t.Context())
-		if err := pool.Cleanup(ctx); err != nil {
-			t.Logf("pool.Cleanup() error: %v", err)
-		}
-		if err := pool.Close(); err != nil {
+		if err := pool.Close(context.WithoutCancel(t.Context())); err != nil {
 			t.Logf("pool.Close() error: %v", err)
 		}
 	})
@@ -173,24 +169,28 @@ func NewPoolT(t *testing.T, endpoint string, opts ...PoolOption) *Pool {
 	return pool
 }
 
-// Close closes the Pool's Docker client if it was created by the Pool.
-// If a custom client was provided via WithMobyClient, it is not closed
-// (the caller remains responsible for closing it).
+// Close cleans up all tracked containers and networks, then closes the Pool's
+// Docker client if it was created by the Pool. If a custom client was provided
+// via WithMobyClient, it is not closed (the caller remains responsible for
+// closing it).
 //
 // It is safe to call Close multiple times.
-func (p *Pool) Close() error {
+func (p *Pool) Close(ctx context.Context) error {
+	cleanupErr := p.cleanup(ctx)
 	if p.ownedClient && p.client != nil {
 		err := p.client.Close()
 		p.client = nil
-		return err
+		if err != nil {
+			return err
+		}
 	}
-	return nil
+	return cleanupErr
 }
 
-// Cleanup removes all containers and networks tracked by this pool.
+// cleanup removes all containers and networks tracked by this pool.
 // Containers are removed first, then networks. Errors during cleanup
 // do not stop the cleanup process. The first error encountered is returned.
-func (p *Pool) Cleanup(ctx context.Context) error {
+func (p *Pool) cleanup(ctx context.Context) error {
 	cleanupCtx := context.WithoutCancel(ctx)
 
 	var firstErr error

--- a/pool.go
+++ b/pool.go
@@ -161,7 +161,7 @@ func NewPoolT(t *testing.T, endpoint string, opts ...PoolOption) *Pool {
 	}
 
 	t.Cleanup(func() {
-		if err := pool.Close(context.WithoutCancel(t.Context())); err != nil {
+		if err := pool.Close(t.Context()); err != nil {
 			t.Logf("pool.Close() error: %v", err)
 		}
 	})
@@ -191,7 +191,8 @@ func (p *Pool) Close(ctx context.Context) error {
 // Containers are removed first, then networks. Errors during cleanup
 // do not stop the cleanup process. The first error encountered is returned.
 func (p *Pool) cleanup(ctx context.Context) error {
-	cleanupCtx := context.WithoutCancel(ctx)
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
+	defer cancel()
 
 	var firstErr error
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -24,7 +24,7 @@ func TestNewPool(t *testing.T) {
 			t.Fatal("NewPool() pool = nil, want non-nil")
 		}
 		t.Cleanup(func() {
-			pool.Close()
+			pool.Close(t.Context())
 		})
 
 		if pool.MaxWait != 60*time.Second {
@@ -42,7 +42,7 @@ func TestNewPool(t *testing.T) {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
 		t.Cleanup(func() {
-			pool.Close()
+			pool.Close(t.Context())
 		})
 
 		if pool.MaxWait != 30*time.Second {
@@ -65,7 +65,7 @@ func TestNewPool(t *testing.T) {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
 		t.Cleanup(func() {
-			pool.Close()
+			pool.Close(t.Context())
 		})
 
 		if pool.client != customClient {
@@ -89,7 +89,7 @@ func TestNewPool(t *testing.T) {
 			t.Fatalf("NewPool() error = %v, want nil (custom client should bypass endpoint)", err)
 		}
 		t.Cleanup(func() {
-			pool.Close()
+			pool.Close(t.Context())
 		})
 	})
 }
@@ -124,7 +124,7 @@ func TestPoolClose(t *testing.T) {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
 
-		err = pool.Close()
+		err = pool.Close(ctx)
 		if err != nil {
 			t.Errorf("Close() error = %v, want nil", err)
 		}
@@ -146,14 +146,13 @@ func TestPoolClose(t *testing.T) {
 		}
 
 		// Close pool - should not close custom client
-		err = pool.Close()
+		err = pool.Close(ctx)
 		if err != nil {
 			t.Errorf("Close() error = %v, want nil", err)
 		}
 
 		// Verify custom client is still usable by pinging
-		ctx2 := t.Context()
-		_, pingErr := customClient.Ping(ctx2, mobyclient.PingOptions{})
+		_, pingErr := customClient.Ping(ctx, mobyclient.PingOptions{})
 		if pingErr != nil {
 			t.Error("custom client was closed by pool.Close(), want it to remain open")
 		}
@@ -169,12 +168,12 @@ func TestPoolCleanup(t *testing.T) {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
 		t.Cleanup(func() {
-			pool.Close()
+			pool.Close(t.Context())
 		})
 
-		err = pool.Cleanup(ctx)
+		err = pool.cleanup(ctx)
 		if err != nil {
-			t.Errorf("Cleanup() error = %v, want nil", err)
+			t.Errorf("cleanup() error = %v, want nil", err)
 		}
 	})
 }
@@ -202,13 +201,13 @@ func TestDefaultPoolsShareReuseScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPool() error = %v", err)
 	}
-	t.Cleanup(func() { poolA.Close() })
+	t.Cleanup(func() { poolA.Close(t.Context()) })
 
 	poolB, err := NewPool(ctx, "")
 	if err != nil {
 		t.Fatalf("NewPool() error = %v", err)
 	}
-	t.Cleanup(func() { poolB.Close() })
+	t.Cleanup(func() { poolB.Close(t.Context()) })
 
 	if poolA.reuseScope != poolB.reuseScope {
 		t.Fatalf("default pools have different reuse scopes: %q vs %q", poolA.reuseScope, poolB.reuseScope)
@@ -231,13 +230,13 @@ func TestCustomClientPoolHasIsolatedScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPool() error = %v", err)
 	}
-	t.Cleanup(func() { poolCustom.Close() })
+	t.Cleanup(func() { poolCustom.Close(t.Context()) })
 
 	poolDefault, err := NewPool(ctx, "")
 	if err != nil {
 		t.Fatalf("NewPool() error = %v", err)
 	}
-	t.Cleanup(func() { poolDefault.Close() })
+	t.Cleanup(func() { poolDefault.Close(t.Context()) })
 
 	if poolCustom.reuseScope == poolDefault.reuseScope {
 		t.Fatal("custom client pool should have isolated reuse scope from default pool")
@@ -261,8 +260,8 @@ func TestPoolCleanupRemovesWithoutReuse(t *testing.T) {
 		WithoutReuse(),
 	)
 
-	if err := pool.Cleanup(t.Context()); err != nil {
-		t.Fatalf("Cleanup() error = %v", err)
+	if err := pool.cleanup(t.Context()); err != nil {
+		t.Fatalf("cleanup() error = %v", err)
 	}
 
 	_, err := pool.client.ContainerInspect(t.Context(), resource.ID(), mobyclient.ContainerInspectOptions{})

--- a/retry_test.go
+++ b/retry_test.go
@@ -163,7 +163,7 @@ func TestPoolRetry(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewPool() error = %v", err)
 		}
-		t.Cleanup(func() { pool.Close() })
+		t.Cleanup(func() { pool.Close(t.Context()) })
 
 		attempts := 0
 		expectedAttempts := 3
@@ -192,7 +192,7 @@ func TestPoolRetry(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewPool() error = %v", err)
 		}
-		t.Cleanup(func() { pool.Close() })
+		t.Cleanup(func() { pool.Close(t.Context()) })
 
 		attempts := 0
 		fn := func() error {


### PR DESCRIPTION
pool.Close() now accepts a context and automatically calls cleanup before closing the Docker client. This prevents mistakes like closing the client before removing containers, which would silently leak containers. The API is simplified: users only call Close(ctx) once at the end.

## Changes

- Close(ctx) now handles both cleanup and client shutdown in the correct order
- Cleanup is now an internal method since it's always called by Close
- NewPoolT simplified to only call Close, not both Cleanup and Close

## Testing

All existing tests pass. The fix makes incorrect ordering impossible by construction.