### PR TITLE
fix: update Kafka port binding to use 127.0.0.1

### DIFF
--- a/examples/Kafka.md
+++ b/examples/Kafka.md
@@ -75,7 +75,7 @@ func main() {
 			"KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1",
 		},
 		PortBindings: map[docker.Port][]docker.PortBinding{
-			"9093/tcp": {{HostIP: "localhost", HostPort: "9093/tcp"}},
+			"9093/tcp": {{HostIP: "127.0.0.1", HostPort: "9093/tcp"}},
 		},
 		ExposedPorts: []string{"9093/tcp"},
 	})


### PR DESCRIPTION
Since Docker Engine v29+ requires an IP (and it does not accept hostnames anymore)
This issue become visible because of https://github.com/actions/runner-images/issues/13474.

Related PR: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1293


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.com](mailto:security@ory.com)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Credits to @skl
