### PR TITLE
fix: race condition when deploying multiple containers simultaneously using dockertest.RunWithOptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ node_modules: package-lock.json
 
 test:
 	go vet ./...
-	go test -covermode=atomic -coverprofile="coverage.out" .
+	go test -race -covermode=atomic -coverprofile="coverage.out" .
 
 
 .DEFAULT_GOAL := help

--- a/dockertest.go
+++ b/dockertest.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -31,6 +32,7 @@ type Pool struct {
 
 // Network represents a docker network.
 type Network struct {
+	mu      sync.RWMutex
 	pool    *Pool
 	Network *dc.Network
 }
@@ -496,7 +498,9 @@ func (d *Pool) RunWithOptions(opts *RunOptions, hcOpts ...func(*dc.HostConfig)) 
 	}
 
 	for _, network := range opts.Networks {
+		network.mu.Lock()
 		network.Network, err = d.Client.NetworkInfo(network.Network.ID)
+		network.mu.Unlock()
 		if err != nil {
 			return nil, err
 		}

--- a/dockertest.go
+++ b/dockertest.go
@@ -164,7 +164,9 @@ func (r *Resource) GetIPInNetwork(network *Network) string {
 		return ""
 	}
 
+	network.mu.RLock()
 	netCfg, ok := r.Container.NetworkSettings.Networks[network.Network.Name]
+	network.mu.RUnlock()
 	if !ok {
 		return ""
 	}
@@ -174,10 +176,12 @@ func (r *Resource) GetIPInNetwork(network *Network) string {
 
 // ConnectToNetwork connects container to network.
 func (r *Resource) ConnectToNetwork(network *Network) error {
+	network.mu.RLock()
 	err := r.pool.Client.ConnectNetwork(
 		network.Network.ID,
 		dc.NetworkConnectionOptions{Container: r.Container.ID},
 	)
+	network.mu.RUnlock()
 	if err != nil {
 		return fmt.Errorf("Failed to connect container to network: %w", err)
 	}
@@ -188,7 +192,9 @@ func (r *Resource) ConnectToNetwork(network *Network) error {
 		return fmt.Errorf("Failed to refresh container information: %w", err)
 	}
 
+	network.mu.Lock()
 	network.Network, err = r.pool.Client.NetworkInfo(network.Network.ID)
+	network.mu.Unlock()
 	if err != nil {
 		return fmt.Errorf("Failed to refresh network information: %w", err)
 	}
@@ -198,10 +204,12 @@ func (r *Resource) ConnectToNetwork(network *Network) error {
 
 // DisconnectFromNetwork disconnects container from network.
 func (r *Resource) DisconnectFromNetwork(network *Network) error {
+	network.mu.RLock()
 	err := r.pool.Client.DisconnectNetwork(
 		network.Network.ID,
 		dc.NetworkConnectionOptions{Container: r.Container.ID},
 	)
+	network.mu.RUnlock()
 	if err != nil {
 		return fmt.Errorf("Failed to connect container to network: %w", err)
 	}
@@ -212,7 +220,9 @@ func (r *Resource) DisconnectFromNetwork(network *Network) error {
 		return fmt.Errorf("Failed to refresh container information: %w", err)
 	}
 
+	network.mu.Lock()
 	network.Network, err = r.pool.Client.NetworkInfo(network.Network.ID)
+	network.mu.Unlock()
 	if err != nil {
 		return fmt.Errorf("Failed to refresh network information: %w", err)
 	}
@@ -700,6 +710,9 @@ func (d *Pool) NetworksByName(name string) ([]Network, error) {
 
 // RemoveNetwork disconnects containers and removes provided network.
 func (d *Pool) RemoveNetwork(network *Network) error {
+	network.mu.RLock()
+	defer network.mu.RUnlock()
+
 	for container := range network.Network.Containers {
 		_ = d.Client.DisconnectNetwork(
 			network.Network.ID,

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -473,6 +474,39 @@ func TestClientRaceCondition(t *testing.T) {
 			)
 			defer pool.Purge(resource)
 		})
+	}
+}
+
+func TestNetworkRaceCondition(t *testing.T) {
+	network, err := pool.CreateNetwork(fmt.Sprintf("test-network-race-condition-%d", time.Now().Unix()))
+	require.NoError(t, err)
+	defer network.Close()
+
+	resources := make([]*dockertest.Resource, 10)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		// Tests must be run in parallel to recreate the issue
+		go func(i int) {
+			defer wg.Done()
+			resource, containerErr := pool.RunWithOptions(
+				&dockertest.RunOptions{
+					Repository: "postgres",
+					Tag:        "13.4",
+					Networks:   []*dockertest.Network{network},
+				},
+			)
+			require.NoError(t, containerErr)
+			resources[i] = resource
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < 10; i++ {
+		resource := resources[i]
+		require.NoError(t, pool.Purge(resource))
 	}
 }
 

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -495,7 +495,7 @@ func TestNetworkRaceCondition(t *testing.T) {
 			resource, containerErr := pool.RunWithOptions(
 				&dockertest.RunOptions{
 					Repository: "postgres",
-					Tag:        "13.4",
+					Tag:        "9.5",
 					Networks:   []*dockertest.Network{network},
 				},
 			)

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -482,10 +482,12 @@ func TestNetworkRaceCondition(t *testing.T) {
 	require.NoError(t, err)
 	defer network.Close()
 
-	resources := make([]*dockertest.Resource, 10)
+	var numContainers = 10
+
+	resources := make([]*dockertest.Resource, numContainers)
 	var wg sync.WaitGroup
 
-	for i := 0; i < 10; i++ {
+	for index := range resources {
 		wg.Add(1)
 		// Tests must be run in parallel to recreate the issue
 		go func(i int) {
@@ -498,16 +500,19 @@ func TestNetworkRaceCondition(t *testing.T) {
 				},
 			)
 			require.NoError(t, containerErr)
+
 			resources[i] = resource
-		}(i)
+		}(index)
 	}
 
 	wg.Wait()
 
-	for i := 0; i < 10; i++ {
-		resource := resources[i]
-		require.NoError(t, pool.Purge(resource))
+	// Clean up resources
+	for resourceIndex := range resources {
+		require.NoError(t, pool.Purge(resources[resourceIndex]))
 	}
+
+	require.NoError(t, pool.RemoveNetwork(network))
 }
 
 func TestExecStatus(t *testing.T) {

--- a/dockertest_test.go
+++ b/dockertest_test.go
@@ -480,7 +480,9 @@ func TestClientRaceCondition(t *testing.T) {
 func TestNetworkRaceCondition(t *testing.T) {
 	network, err := pool.CreateNetwork(fmt.Sprintf("test-network-race-condition-%d", time.Now().Unix()))
 	require.NoError(t, err)
-	defer network.Close()
+	t.Cleanup(func() {
+		require.NoError(t, pool.RemoveNetwork(network))
+	})
 
 	var numContainers = 10
 
@@ -501,18 +503,13 @@ func TestNetworkRaceCondition(t *testing.T) {
 			)
 			require.NoError(t, containerErr)
 
-			resources[i] = resource
+			t.Cleanup(func() {
+				require.NoError(t, pool.Purge(resource))
+			})
 		}(index)
 	}
 
 	wg.Wait()
-
-	// Clean up resources
-	for resourceIndex := range resources {
-		require.NoError(t, pool.Purge(resources[resourceIndex]))
-	}
-
-	require.NoError(t, pool.RemoveNetwork(network))
 }
 
 func TestExecStatus(t *testing.T) {


### PR DESCRIPTION
When trying to deploy multiple containers via goroutines, there is a race condition since the Network struct is used in the RunWithOptions method as below

```
for _, network := range opts.Networks {
	network.Network, err = d.Client.NetworkInfo(network.Network.ID)
	if err != nil {
		return nil, err
	}
}
```

We encountered this because we are deploying multiple different containers to prepare our test suite and therefore to save time we use goroutines and call the RunWithOptions from inside them.

This PR introduces a mutex in the `Network` struct so that this race condition will not happen.

## Related Issue or Design Document

#586 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).
