### PR TITLE
refactor: replace Managed* wrappers with interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,14 +239,10 @@ resource := pool.RunT(t, "postgres",
 
 ### Container reuse
 
-> [!WARNING]
->
-> Do not use `resource.Cleanup(t)` on reused containers. Because reused
-> containers are shared across tests, cleaning up one reference will remove the
-> container for all other tests that depend on it. Only use `pool.Close(ctx)` in
-> `TestMain` to clean up reused containers after all tests have finished.
-
-Containers are automatically reused based on `repository:tag`:
+Containers are automatically reused based on `repository:tag`. Reuse is
+reference-counted: each `Run`/`RunT` call increments the ref count, and each
+`Close`/cleanup decrements it. The container is only removed from Docker when
+the last reference is released.
 
 ```go
 // First test creates container
@@ -402,39 +398,38 @@ net, err := pool.CreateNetwork(ctx, "my-network", &dockertest.NetworkCreateOptio
 
 ### Cleanup
 
-> [!WARNING]
->
-> Do not use `resource.Cleanup(t)` or `resource.CloseT(t)` on **reused**
-> containers. Because reused containers are shared across tests, cleaning up one
-> reference removes the container for all other tests. Use `pool.Close(ctx)` in
-> `TestMain` to clean up reused containers after all tests finish.
-
-Use `Cleanup(t)` for **non-reused** containers — it registers `t.Cleanup` and
-logs errors without failing the test:
+**`NewPoolT` + `RunT` (recommended):** Cleanup is fully automatic. `RunT`
+registers cleanup via `t.Cleanup`, and the pool is closed when the test
+finishes. Nothing to do.
 
 ```go
-resource := pool.RunT(t, "postgres",
-    dockertest.WithTag("14"),
-    dockertest.WithoutReuse(),
-)
-resource.Cleanup(t) // removed when t finishes
+func TestDB(t *testing.T) {
+    pool := dockertest.NewPoolT(t, "")
+    resource := pool.RunT(t, "postgres", dockertest.WithTag("14"))
+    // Use resource... cleanup happens automatically when t finishes.
+}
 ```
 
-Use `CloseT(t)` when you need **immediate** cleanup and want a hard failure on
-error (calls `t.Fatalf`):
+**`NewPool` + `Run`:** Call `resource.Close(ctx)` to release individual
+containers, or `pool.Close(ctx)` to release everything:
 
 ```go
-resource.CloseT(t) // removes now, fails test on error
+ctx := context.Background()
+pool, err := dockertest.NewPool(ctx, "")
+if err != nil {
+    panic(err)
+}
+defer pool.Close(ctx) // releases all tracked containers and networks
+
+resource, err := pool.Run(ctx, "postgres", dockertest.WithTag("14"))
+if err != nil {
+    panic(err)
+}
+defer resource.Close(ctx) // or let pool.Close handle it
 ```
 
-Use `Close(ctx)` in non-test code for manual cleanup:
-
-```go
-err := resource.Close(ctx)
-```
-
-Use `pool.Close(ctx)` to clean up **all** resources (reused and non-reused),
-typically in `TestMain`:
+**Advanced: shared pool in `TestMain`:** Use this when you need a single pool
+shared across all tests in a package:
 
 ```go
 func TestMain(m *testing.M) {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -57,11 +57,11 @@ intended due to Docker API limitations.
 v4 offers two pool creation patterns for tests. **Choose A or B per package, do
 not mix them** — mixing causes double-close or resource leaks.
 
-**Option A: `NewPoolT` (recommended for most tests)**
+**Option A: `NewPoolT` (recommended for most tests — no `TestMain` needed)**
 
 `NewPoolT` registers cleanup automatically via `t.Cleanup`. All tracked
-containers and networks are removed when the test finishes. No `TestMain`
-needed.
+containers and networks are removed when the test finishes. Self-contained: no
+`TestMain` needed.
 
 ```go
 // v4 — cleanup is automatic
@@ -70,7 +70,7 @@ pool := dockertest.NewPoolT(t, "",
 )
 ```
 
-**Option B: `NewPool` + `TestMain` (for shared pools across tests)**
+**Option B: `NewPool` + `TestMain` (for shared pools — advanced)**
 
 Use this when you want a single pool shared across all tests in a package. You
 must call `pool.Close(ctx)` explicitly.
@@ -254,8 +254,8 @@ Available sentinel errors: `ErrImagePullFailed`, `ErrContainerCreateFailed`,
    - `pool.Purge(resource)` → automatic via `NewPoolT`, or `pool.Close(ctx)` in
      `TestMain`
    - `pool.Retry(fn)` → `pool.Retry(ctx, timeout, fn)`
-   - For non-reused containers needing per-test cleanup: `WithoutReuse()` +
-     `resource.Cleanup(t)`
+   - For non-reused containers: use `WithoutReuse()` (cleanup is automatic with
+     `RunT`, or call `resource.Close(ctx)` with `Run`)
    - See [Breaking Changes](#breaking-changes) for full patterns.
 
 4. **Test:** Run `go test ./...` to verify the migration.
@@ -315,14 +315,6 @@ cache := pool.RunT(t, "redis", dockertest.WithTag("7"))
 > containers that share an image but differ in configuration (see
 > [Custom Reuse ID](#custom-reuse-id-different-configs) below).
 
-> [!WARNING]
->
-> Do not use `resource.Cleanup(t)` on reused containers. Because reused
-> containers are shared across tests, cleaning up one reference will remove the
-> container for all other tests that depend on it. Only use `pool.Close(ctx)`
-> (automatic with `NewPoolT`) to clean up reused containers after all tests have
-> finished.
-
 v4 automatically reuses containers with the same `repo:tag` across tests. Each
 `NewPoolT` call creates a separate pool, but containers are still shared because
 default pools use a common reuse scope:
@@ -346,7 +338,7 @@ resource := pool.RunT(t, "postgres",
     dockertest.WithTag("14"),
     dockertest.WithoutReuse(),
 )
-resource.Cleanup(t) // Safe — this container is not shared
+// Cleanup is automatic via RunT
 ```
 
 ### Custom Reuse ID (Different Configs)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -77,7 +77,7 @@ must call `pool.Close(ctx)` explicitly.
 
 ```go
 // v4 — shared pool, manual cleanup
-var pool *dockertest.Pool
+var pool dockertest.ClosablePool
 
 func TestMain(m *testing.M) {
     ctx := context.Background()
@@ -429,9 +429,9 @@ v4 maintains a global in-memory registry for container reuse. You typically do
 not need these functions directly — `Pool.Run` and `Pool.RunT` use them
 automatically. They are useful for custom cleanup or inspection:
 
-- `Register(reuseID, resource)` — stores a resource (idempotent; keeps existing)
-- `Get(reuseID)` — retrieves a resource by reuse ID
-- `GetAll()` — returns all registered resources
+- `Register(reuseID string, r ClosableResource) error` — stores a resource (idempotent; keeps existing)
+- `Get(reuseID string) (ClosableResource, bool)` — retrieves a resource by reuse ID
+- `GetAll() []ClosableResource` — returns all registered resources
 - `ResetRegistry()` — clears the registry (does **not** stop containers)
 
 ### Immediate Cleanup with `CloseT`
@@ -441,7 +441,10 @@ and calls `t.Fatalf` on error. Use this when you need teardown at a specific
 point rather than relying on pool-scoped cleanup:
 
 ```go
-resource := pool.RunT(t, "postgres", dockertest.WithTag("14"), dockertest.WithoutReuse())
+resource, err := pool.Run(t.Context(), "postgres", dockertest.WithTag("14"), dockertest.WithoutReuse())
+if err != nil {
+    t.Fatal(err)
+}
 // ... use resource ...
 resource.CloseT(t) // immediate removal
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -429,8 +429,10 @@ v4 maintains a global in-memory registry for container reuse. You typically do
 not need these functions directly — `Pool.Run` and `Pool.RunT` use them
 automatically. They are useful for custom cleanup or inspection:
 
-- `Register(reuseID string, r ClosableResource) error` — stores a resource (idempotent; keeps existing)
-- `Get(reuseID string) (ClosableResource, bool)` — retrieves a resource by reuse ID
+- `Register(reuseID string, r ClosableResource) error` — stores a resource
+  (idempotent; keeps existing)
+- `Get(reuseID string) (ClosableResource, bool)` — retrieves a resource by reuse
+  ID
 - `GetAll() []ClosableResource` — returns all registered resources
 - `ResetRegistry()` — clears the registry (does **not** stop containers)
 

--- a/build.go
+++ b/build.go
@@ -74,7 +74,7 @@ type BuildOptions struct {
 //		panic(err)
 //	}
 //	defer resource.Close(ctx)
-func (p *Pool) BuildAndRun(ctx context.Context, name string, buildOpts *BuildOptions, runOpts ...RunOption) (*Resource, error) {
+func (p *pool) BuildAndRun(ctx context.Context, name string, buildOpts *BuildOptions, runOpts ...RunOption) (ClosableResource, error) {
 	if buildOpts == nil {
 		return nil, fmt.Errorf("buildOpts cannot be nil")
 	}
@@ -160,13 +160,17 @@ func (p *Pool) BuildAndRun(ctx context.Context, name string, buildOpts *BuildOpt
 }
 
 // BuildAndRunT is a test helper that uses t.Context() and calls t.Fatalf on error.
-func (p *Pool) BuildAndRunT(t TestingTB, name string, buildOpts *BuildOptions, runOpts ...RunOption) *Resource {
+// The returned ManagedResource does not expose Close, CloseT, or Cleanup;
+// the resource is automatically cleaned up when the test finishes.
+func (p *pool) BuildAndRunT(t TestingTB, name string, buildOpts *BuildOptions, runOpts ...RunOption) Resource {
 	t.Helper()
 
 	r, err := p.BuildAndRun(t.Context(), name, buildOpts, runOpts...)
 	if err != nil {
 		t.Fatalf("BuildAndRunT failed: %v", err)
 	}
+
+	r.Cleanup(t)
 
 	return r
 }

--- a/build_test.go
+++ b/build_test.go
@@ -54,8 +54,6 @@ CMD ["sleep", "300"]
 		t.Fatal("Resource has empty container ID")
 	}
 
-	// Cleanup
-	r.CloseT(t)
 }
 
 func TestBuildAndRunWithBuildArgs(t *testing.T) {
@@ -93,7 +91,6 @@ CMD ["sh", "-c", "echo TEST_ENV=$TEST_ENV && sleep 300"]
 	}
 
 	r := pool.BuildAndRunT(t, "test-build-args", buildOpts)
-	t.Cleanup(func() { r.Close(t.Context()) })
 
 	// Verify build arg was applied by checking container env via logs
 	var logs string
@@ -146,7 +143,6 @@ CMD ["sh", "-c", "echo $TEST_VAR && sleep 300"]
 	r := pool.BuildAndRunT(t, "test-build-env", buildOpts,
 		dockertest.WithEnv([]string{"TEST_VAR=hello"}),
 	)
-	t.Cleanup(func() { r.Close(t.Context()) })
 
 	// Verify env var took effect via logs
 	var logs string
@@ -213,8 +209,6 @@ func TestBuildAndRunWithBuildContext(t *testing.T) {
 		t.Fatalf("Expected logs to contain 'Hello, World!', got: %s (error: %v)", logs, err)
 	}
 
-	// Cleanup
-	r.CloseT(t)
 }
 
 func TestBuildAndRunWithTaggedName(t *testing.T) {
@@ -244,11 +238,9 @@ CMD ["sleep", "300"]
 		ContextDir: tmpDir,
 	})
 
-	if r.Container.Config.Image != imageRef {
-		t.Fatalf("container image = %q, want %q", r.Container.Config.Image, imageRef)
+	if r.Container().Config.Image != imageRef {
+		t.Fatalf("container image = %q, want %q", r.Container().Config.Image, imageRef)
 	}
-
-	r.CloseT(t)
 }
 
 func TestRunUsesLocalImageWithoutPull(t *testing.T) {
@@ -275,15 +267,13 @@ CMD ["sleep", "300"]
 	// If Run attempts a pull, this registry will fail DNS resolution.
 	repository := "example.invalid/dockertest-local-skip-pull"
 
-	first := pool.BuildAndRunT(t, repository, &dockertest.BuildOptions{
+	pool.BuildAndRunT(t, repository, &dockertest.BuildOptions{
 		Dockerfile: "Dockerfile",
 		ContextDir: tmpDir,
 	}, dockertest.WithoutReuse())
-	first.CloseT(t)
 
-	second := pool.RunT(t, repository,
+	pool.RunT(t, repository,
 		dockertest.WithTag("latest"),
 		dockertest.WithoutReuse(),
 	)
-	second.CloseT(t)
 }

--- a/cleanup_integration_test.go
+++ b/cleanup_integration_test.go
@@ -1,0 +1,229 @@
+// Copyright © 2026 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package dockertest_test
+
+import (
+	"testing"
+
+	"github.com/containerd/errdefs"
+	mobyclient "github.com/moby/moby/client"
+	dockertest "github.com/ory/dockertest/v4"
+)
+
+func TestCleanupAfterSubtests(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	dc, err := mobyclient.New(mobyclient.FromEnv)
+	if err != nil {
+		t.Fatalf("mobyclient.New() error = %v", err)
+	}
+	t.Cleanup(func() { dc.Close() })
+
+	var containerIDs []string
+
+	t.Run("postgres-passes", func(t *testing.T) {
+		pool := dockertest.NewPoolT(t, "")
+		r := pool.RunT(t, "alpine",
+			dockertest.WithCmd([]string{"sleep", "300"}),
+			dockertest.WithoutReuse(),
+		)
+		containerIDs = append(containerIDs, r.ID())
+	})
+
+	t.Run("redis-passes", func(t *testing.T) {
+		pool := dockertest.NewPoolT(t, "")
+		r := pool.RunT(t, "alpine",
+			dockertest.WithTag("3.19"),
+			dockertest.WithCmd([]string{"sleep", "300"}),
+			dockertest.WithoutReuse(),
+		)
+		containerIDs = append(containerIDs, r.ID())
+	})
+
+	t.Run("third-container", func(t *testing.T) {
+		pool := dockertest.NewPoolT(t, "")
+		r := pool.RunT(t, "alpine",
+			dockertest.WithCmd([]string{"sleep", "300"}),
+			dockertest.WithoutReuse(),
+		)
+		containerIDs = append(containerIDs, r.ID())
+	})
+
+	for _, id := range containerIDs {
+		_, err := dc.ContainerInspect(t.Context(), id, mobyclient.ContainerInspectOptions{})
+		if !errdefs.IsNotFound(err) {
+			t.Fatalf("ContainerInspect(%s) after subtests: error = %v, want not found", id, err)
+		}
+	}
+}
+
+func TestCleanupRefCountingTwoRefs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	dc, err := mobyclient.New(mobyclient.FromEnv)
+	if err != nil {
+		t.Fatalf("mobyclient.New() error = %v", err)
+	}
+	t.Cleanup(func() { dc.Close() })
+
+	var containerID string
+
+	t.Run("two-refs", func(t *testing.T) {
+		pool := dockertest.NewPoolT(t, "")
+		r1 := pool.RunT(t, "alpine",
+			dockertest.WithCmd([]string{"sleep", "300"}),
+		)
+		r2 := pool.RunT(t, "alpine",
+			dockertest.WithCmd([]string{"sleep", "300"}),
+		)
+		if r1.ID() != r2.ID() {
+			t.Fatalf("expected same container ID, got %s and %s", r1.ID(), r2.ID())
+		}
+		containerID = r1.ID()
+	})
+
+	_, err = dc.ContainerInspect(t.Context(), containerID, mobyclient.ContainerInspectOptions{})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("ContainerInspect(%s) after subtest: error = %v, want not found", containerID, err)
+	}
+}
+
+func TestCleanupSubtestBeforeParent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	dc, err := mobyclient.New(mobyclient.FromEnv)
+	if err != nil {
+		t.Fatalf("mobyclient.New() error = %v", err)
+	}
+	t.Cleanup(func() { dc.Close() })
+
+	var containerID string
+
+	t.Run("parent", func(t *testing.T) {
+		pool := dockertest.NewPoolT(t, "")
+
+		t.Run("child", func(t *testing.T) {
+			r := pool.RunT(t, "alpine",
+				dockertest.WithoutReuse(),
+				dockertest.WithCmd([]string{"sleep", "300"}),
+			)
+			containerID = r.ID()
+		})
+
+		// After child subtest completes, its cleanup should have already run.
+		_, err := dc.ContainerInspect(t.Context(), containerID, mobyclient.ContainerInspectOptions{})
+		if !errdefs.IsNotFound(err) {
+			t.Fatalf("ContainerInspect(%s) after child subtest: error = %v, want not found", containerID, err)
+		}
+	})
+}
+
+func TestCleanupRefCountingParentChild(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	dc, err := mobyclient.New(mobyclient.FromEnv)
+	if err != nil {
+		t.Fatalf("mobyclient.New() error = %v", err)
+	}
+	t.Cleanup(func() { dc.Close() })
+
+	var containerID string
+
+	t.Run("parent-holds-ref", func(t *testing.T) {
+		// Parent acquires ref via RunT: refs=1
+		parentPool := dockertest.NewPoolT(t, "")
+		r1 := parentPool.RunT(t, "alpine",
+			dockertest.WithCmd([]string{"sleep", "300"}),
+		)
+		containerID = r1.ID()
+
+		t.Run("child-acquires-second-ref", func(t *testing.T) {
+			// Child acquires second ref to same container: refs=2
+			childPool := dockertest.NewPoolT(t, "")
+			r2 := childPool.RunT(t, "alpine",
+				dockertest.WithCmd([]string{"sleep", "300"}),
+			)
+			if r2.ID() != containerID {
+				t.Fatalf("expected same container ID %s, got %s", containerID, r2.ID())
+			}
+		})
+
+		// After child subtest: child's cleanup released one ref (refs=1).
+		// Container should still be alive because parent's ref remains.
+		_, err := dc.ContainerInspect(t.Context(), containerID, mobyclient.ContainerInspectOptions{})
+		if err != nil {
+			t.Fatalf("ContainerInspect(%s) after child cleanup: error = %v, want container still alive", containerID, err)
+		}
+	})
+
+	// After parent subtest: parent's cleanup released last ref (refs=0).
+	// Container should now be removed from Docker.
+	_, err = dc.ContainerInspect(t.Context(), containerID, mobyclient.ContainerInspectOptions{})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("ContainerInspect(%s) after parent cleanup: error = %v, want not found", containerID, err)
+	}
+}
+
+func TestNoTestMainNeeded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	dc, err := mobyclient.New(mobyclient.FromEnv)
+	if err != nil {
+		t.Fatalf("mobyclient.New() error = %v", err)
+	}
+	t.Cleanup(func() { dc.Close() })
+
+	var containerID string
+
+	t.Run("run-and-cleanup", func(t *testing.T) {
+		pool := dockertest.NewPoolT(t, "")
+		r := pool.RunT(t, "alpine",
+			dockertest.WithCmd([]string{"sleep", "300"}),
+			dockertest.WithoutReuse(),
+		)
+		containerID = r.ID()
+	})
+
+	// No TestMain exists in this file — NewPoolT + RunT handles all cleanup
+	// via t.Cleanup callbacks without requiring any global teardown.
+	_, err = dc.ContainerInspect(t.Context(), containerID, mobyclient.ContainerInspectOptions{})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("ContainerInspect(%s) after subtest: error = %v, want not found (no TestMain needed)", containerID, err)
+	}
+}

--- a/examples/build_dockerfile_test.go
+++ b/examples/build_dockerfile_test.go
@@ -26,8 +26,6 @@ func TestBuildDockerfile(t *testing.T) {
 			Dockerfile: "Dockerfile",
 		},
 	)
-	resource.Cleanup(t)
-
 	dsn := fmt.Sprintf("postgres://postgres:secret@%s/testdb?sslmode=disable",
 		resource.GetHostPort("5432/tcp"))
 	db, err := sql.Open("postgres", dsn)

--- a/examples/cassandra_test.go
+++ b/examples/cassandra_test.go
@@ -25,8 +25,6 @@ func TestCassandra(t *testing.T) {
 			"CASSANDRA_AUTHENTICATOR=PasswordAuthenticator",
 		}),
 	)
-	cassandra.Cleanup(t)
-
 	host := cassandra.GetBoundIP("9042/tcp")
 	port, err := strconv.Atoi(cassandra.GetPort("9042/tcp"))
 	if err != nil {

--- a/examples/cleanup_test.go
+++ b/examples/cleanup_test.go
@@ -1,0 +1,96 @@
+// Copyright © 2026 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package examples_test
+
+import (
+	"testing"
+
+	"github.com/containerd/errdefs"
+	mobyclient "github.com/moby/moby/client"
+
+	"github.com/ory/dockertest/v4"
+)
+
+// TestExplicitCleanup demonstrates explicit resource lifecycle management
+// using NewPool/Run/Close directly, without any *T helper auto-cleanup.
+func TestExplicitCleanup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := t.Context()
+
+	// Standalone Docker client for verification only.
+	dc, err := mobyclient.New(mobyclient.FromEnv)
+	if err != nil {
+		t.Fatalf("creating docker client: %v", err)
+	}
+	t.Cleanup(func() { dc.Close() })
+
+	// Create pool explicitly — caller owns Close.
+	pool, err := dockertest.NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("creating pool: %v", err)
+	}
+
+	// Run a non-reused container (refs not tracked in registry).
+	containerA, err := pool.Run(ctx, "alpine",
+		dockertest.WithTag("latest"),
+		dockertest.WithCmd([]string{"sleep", "300"}),
+		dockertest.WithoutReuse(),
+	)
+	if err != nil {
+		t.Fatalf("running containerA: %v", err)
+	}
+	containerAID := containerA.ID()
+
+	// Run a reused container (refs=1).
+	containerB1, err := pool.Run(ctx, "alpine",
+		dockertest.WithTag("latest"),
+		dockertest.WithCmd([]string{"sleep", "300"}),
+	)
+	if err != nil {
+		t.Fatalf("running containerB1: %v", err)
+	}
+
+	// Run the same reused container again (refs=2).
+	containerB2, err := pool.Run(ctx, "alpine",
+		dockertest.WithTag("latest"),
+		dockertest.WithCmd([]string{"sleep", "300"}),
+	)
+	if err != nil {
+		t.Fatalf("running containerB2: %v", err)
+	}
+	containerBID := containerB1.ID()
+
+	if containerB1.ID() != containerB2.ID() {
+		t.Fatalf("expected containerB1 and containerB2 to share the same ID, got %s and %s", containerB1.ID(), containerB2.ID())
+	}
+
+	// Close containerA — it has no reuse ref-count, so it is removed immediately.
+	if err := containerA.Close(ctx); err != nil {
+		t.Fatalf("closing containerA: %v", err)
+	}
+	_, err = dc.ContainerInspect(ctx, containerAID, mobyclient.ContainerInspectOptions{})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("containerA should be removed, got inspect error: %v", err)
+	}
+
+	// Close containerB1 (refs drops to 1) — container must still exist.
+	if err := containerB1.Close(ctx); err != nil {
+		t.Fatalf("closing containerB1: %v", err)
+	}
+	if _, err := dc.ContainerInspect(ctx, containerBID, mobyclient.ContainerInspectOptions{}); err != nil {
+		t.Fatalf("containerB should still exist after closing one ref, got: %v", err)
+	}
+
+	// pool.Close releases containerB2's ref (last ref) and closes the client.
+	if err := pool.Close(ctx); err != nil {
+		t.Fatalf("closing pool: %v", err)
+	}
+	_, err = dc.ContainerInspect(ctx, containerBID, mobyclient.ContainerInspectOptions{})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("containerB should be removed after pool.Close, got inspect error: %v", err)
+	}
+}

--- a/examples/cockroachdb_test.go
+++ b/examples/cockroachdb_test.go
@@ -23,8 +23,6 @@ func TestCockroachDB(t *testing.T) {
 		dockertest.WithTag("v24.3.2"),
 		dockertest.WithCmd([]string{"start-single-node", "--insecure"}),
 	)
-	cockroach.Cleanup(t)
-
 	// Open connection outside retry loop to avoid leaking connection pools
 	dsn := fmt.Sprintf("postgres://root@%s/defaultdb?sslmode=disable",
 		cockroach.GetHostPort("26257/tcp"))

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -39,8 +39,8 @@ require (
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/moby/api v1.52.0 // indirect
-	github.com/moby/moby/client v0.2.1 // indirect
+	github.com/moby/moby/api v1.54.0 // indirect
+	github.com/moby/moby/client v0.3.0 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -77,10 +77,10 @@ github.com/minio/minio-go/v7 v7.0.98 h1:MeAVKjLVz+XJ28zFcuYyImNSAh8Mq725uNW4beRi
 github.com/minio/minio-go/v7 v7.0.98/go.mod h1:cY0Y+W7yozf0mdIclrttzo1Iiu7mEf9y7nk2uXqMOvM=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
-github.com/moby/moby/api v1.52.0 h1:00BtlJY4MXkkt84WhUZPRqt5TvPbgig2FZvTbe3igYg=
-github.com/moby/moby/api v1.52.0/go.mod h1:8mb+ReTlisw4pS6BRzCMts5M49W5M7bKt1cJy/YbAqc=
-github.com/moby/moby/client v0.2.1 h1:1Grh1552mvv6i+sYOdY+xKKVTvzJegcVMhuXocyDz/k=
-github.com/moby/moby/client v0.2.1/go.mod h1:O+/tw5d4a1Ha/ZA/tPxIZJapJRUS6LNZ1wiVRxYHyUE=
+github.com/moby/moby/api v1.54.0 h1:7kbUgyiKcoBhm0UrWbdrMs7RX8dnwzURKVbZGy2GnL0=
+github.com/moby/moby/api v1.54.0/go.mod h1:8mb+ReTlisw4pS6BRzCMts5M49W5M7bKt1cJy/YbAqc=
+github.com/moby/moby/client v0.3.0 h1:UUGL5okry+Aomj3WhGt9Aigl3ZOxZGqR7XPo+RLPlKs=
+github.com/moby/moby/client v0.3.0/go.mod h1:HJgFbJRvogDQjbM8fqc1MCEm4mIAGMLjXbgwoZp6jCQ=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/examples/minio_test.go
+++ b/examples/minio_test.go
@@ -29,8 +29,6 @@ func TestMinio(t *testing.T) {
 			"MINIO_ROOT_PASSWORD=minioadmin",
 		}),
 	)
-	resource.Cleanup(t)
-
 	endpoint := resource.GetHostPort("9000/tcp")
 
 	// Wait for MinIO to be ready via health endpoint

--- a/examples/mongodb_test.go
+++ b/examples/mongodb_test.go
@@ -22,8 +22,6 @@ func TestMongoDB(t *testing.T) {
 	mongodb := pool.RunT(t, "mongo",
 		dockertest.WithTag("7"),
 	)
-	mongodb.Cleanup(t)
-
 	// Create MongoDB client outside retry loop to avoid leaking connections
 	ctx := t.Context()
 	uri := "mongodb://" + mongodb.GetHostPort("27017/tcp")

--- a/examples/mountebank_test.go
+++ b/examples/mountebank_test.go
@@ -24,8 +24,6 @@ func TestMountebank(t *testing.T) {
 		dockertest.WithCmd([]string{"--allowInjection"}),
 		dockertest.WithoutReuse(),
 	)
-	mb.Cleanup(t)
-
 	adminURL := fmt.Sprintf("http://%s", mb.GetHostPort("2525/tcp"))
 
 	err := pool.Retry(t.Context(), 30*time.Second, func() error {

--- a/examples/multi_container_test.go
+++ b/examples/multi_container_test.go
@@ -21,9 +21,6 @@ func TestMultipleContainers(t *testing.T) {
 	pool := dockertest.NewPoolT(t, "")
 
 	net := pool.CreateNetworkT(t, "dockertest-multi-example", nil)
-	t.Cleanup(func() {
-		net.CloseT(t)
-	})
 
 	// Start two PostgreSQL containers on the same network
 	pg1 := pool.RunT(t, "postgres",
@@ -34,7 +31,6 @@ func TestMultipleContainers(t *testing.T) {
 		}),
 		dockertest.WithoutReuse(),
 	)
-	pg1.Cleanup(t)
 
 	pg2 := pool.RunT(t, "postgres",
 		dockertest.WithTag("14-alpine"),
@@ -44,7 +40,6 @@ func TestMultipleContainers(t *testing.T) {
 		}),
 		dockertest.WithoutReuse(),
 	)
-	pg2.Cleanup(t)
 
 	// Connect both containers to the shared network
 	if err := pg1.ConnectToNetwork(t.Context(), net); err != nil {
@@ -68,7 +63,7 @@ func TestMultipleContainers(t *testing.T) {
 	// Wait for both databases via host ports
 	for _, tc := range []struct {
 		name     string
-		resource *dockertest.Resource
+		resource dockertest.Resource
 		dbName   string
 	}{
 		{"pg1", pg1, "db1"},

--- a/examples/mysql_test.go
+++ b/examples/mysql_test.go
@@ -26,8 +26,6 @@ func TestMySQL(t *testing.T) {
 			"MYSQL_DATABASE=testdb",
 		}),
 	)
-	mysql.Cleanup(t)
-
 	// Open connection outside retry loop to avoid leaking connection pools
 	dsn := fmt.Sprintf("root:secret@tcp(%s)/testdb",
 		mysql.GetHostPort("3306/tcp"))

--- a/examples/postgres_test.go
+++ b/examples/postgres_test.go
@@ -26,8 +26,6 @@ func TestPostgreSQL(t *testing.T) {
 			"POSTGRES_DB=testdb",
 		}),
 	)
-	postgres.Cleanup(t)
-
 	// Open connection outside retry loop to avoid leaking connection pools
 	dsn := fmt.Sprintf("postgres://postgres:secret@%s/testdb?sslmode=disable",
 		postgres.GetHostPort("5432/tcp"))

--- a/examples/redis_test.go
+++ b/examples/redis_test.go
@@ -20,8 +20,6 @@ func TestRedis(t *testing.T) {
 	redisContainer := pool.RunT(t, "redis",
 		dockertest.WithTag("7-alpine"),
 	)
-	redisContainer.Cleanup(t)
-
 	// Create Redis client
 	addr := redisContainer.GetHostPort("6379/tcp")
 	client := redis.NewClient(&redis.Options{

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -40,5 +40,6 @@ type DockerClient interface {
 	NetworkList(ctx context.Context, options mobyclient.NetworkListOptions) (mobyclient.NetworkListResult, error)
 
 	Ping(ctx context.Context, options mobyclient.PingOptions) (mobyclient.PingResult, error)
+	DaemonHost() string
 	Close() error
 }

--- a/network.go
+++ b/network.go
@@ -11,19 +11,39 @@ import (
 	"strings"
 
 	"github.com/containerd/errdefs"
-	"github.com/moby/moby/api/types/network"
+	mobynetwork "github.com/moby/moby/api/types/network"
 	mobyclient "github.com/moby/moby/client"
 )
 
-// Network represents a Docker network managed by dockertest.
-// Networks allow containers to communicate with each other using container names
-// as hostnames, isolated from other networks.
-//
-// Create networks with Pool.CreateNetwork and connect containers with
-// Resource.ConnectToNetwork.
-type Network struct {
-	pool    *Pool
-	Network network.Inspect
+// Network provides access to a Docker network.
+// Returned by CreateNetworkT; does not expose Close or CloseT.
+type Network interface {
+	ID() string
+	Inspect() mobynetwork.Inspect
+}
+
+// ClosableNetwork extends Network with explicit lifecycle management.
+// Returned by CreateNetwork; the caller is responsible for calling Close.
+type ClosableNetwork interface {
+	Network
+	Close(ctx context.Context) error
+	CloseT(t TestingTB)
+}
+
+// dockerNetwork represents a Docker network managed by dockertest.
+type dockerNetwork struct {
+	pool    *pool
+	inspect mobynetwork.Inspect
+}
+
+// ID returns the network ID.
+func (n *dockerNetwork) ID() string {
+	return n.inspect.ID
+}
+
+// Inspect returns the network inspection response.
+func (n *dockerNetwork) Inspect() mobynetwork.Inspect {
+	return n.inspect
 }
 
 // NetworkCreateOptions holds options for creating a network.
@@ -49,11 +69,9 @@ type NetworkCreateOptions struct {
 
 // CreateNetwork creates a new Docker network with the given name and options.
 // If opts is nil, default network options are used (bridge driver, external access allowed).
-func (p *Pool) CreateNetwork(ctx context.Context, name string, opts *NetworkCreateOptions) (*Network, error) {
-	// Build network create options
+func (p *pool) CreateNetwork(ctx context.Context, name string, opts *NetworkCreateOptions) (ClosableNetwork, error) {
 	createOpts := mobyclient.NetworkCreateOptions{}
 
-	// Apply custom options if provided
 	if opts != nil {
 		createOpts.Driver = opts.Driver
 		createOpts.Internal = opts.Internal
@@ -67,7 +85,6 @@ func (p *Pool) CreateNetwork(ctx context.Context, name string, opts *NetworkCrea
 		createOpts.Options = opts.Options
 	}
 
-	// Create the network
 	createResp, err := p.client.NetworkCreate(ctx, name, createOpts)
 	if err != nil {
 		createResp, err = p.retryNetworkCreateWithCustomSubnet(ctx, name, createOpts, err)
@@ -76,24 +93,22 @@ func (p *Pool) CreateNetwork(ctx context.Context, name string, opts *NetworkCrea
 		}
 	}
 
-	// Inspect the network to get full details
 	inspectResp, err := p.client.NetworkInspect(ctx, createResp.ID, mobyclient.NetworkInspectOptions{})
 	if err != nil {
-		// Clean up network on inspect failure
 		_, _ = p.client.NetworkRemove(ctx, createResp.ID, mobyclient.NetworkRemoveOptions{}) //nolint:errcheck // Best effort cleanup
 		return nil, err
 	}
 
-	net := &Network{
+	net := &dockerNetwork{
 		pool:    p,
-		Network: inspectResp.Network,
+		inspect: inspectResp.Network,
 	}
 	p.trackNetwork(net)
 
 	return net, nil
 }
 
-func (p *Pool) retryNetworkCreateWithCustomSubnet(
+func (p *pool) retryNetworkCreateWithCustomSubnet(
 	ctx context.Context,
 	name string,
 	createOpts mobyclient.NetworkCreateOptions,
@@ -118,9 +133,9 @@ func (p *Pool) retryNetworkCreateWithCustomSubnet(
 		}
 
 		retryOpts := createOpts
-		retryOpts.IPAM = &network.IPAM{
+		retryOpts.IPAM = &mobynetwork.IPAM{
 			Driver: "default",
-			Config: []network.IPAMConfig{
+			Config: []mobynetwork.IPAMConfig{
 				{Subnet: prefix},
 			},
 		}
@@ -142,7 +157,9 @@ func (p *Pool) retryNetworkCreateWithCustomSubnet(
 }
 
 // CreateNetworkT creates a network using t.Context() and calls t.Fatalf on error.
-func (p *Pool) CreateNetworkT(t TestingTB, name string, opts *NetworkCreateOptions) *Network {
+// The returned Network does not expose Close or CloseT; the network is
+// cleaned up automatically when the pool is closed.
+func (p *pool) CreateNetworkT(t TestingTB, name string, opts *NetworkCreateOptions) Network {
 	t.Helper()
 
 	net, err := p.CreateNetwork(t.Context(), name, opts)
@@ -156,99 +173,24 @@ func (p *Pool) CreateNetworkT(t TestingTB, name string, opts *NetworkCreateOptio
 // Close removes the network.
 // Any containers still connected to the network should be disconnected first,
 // or the network removal will fail.
-func (n *Network) Close(ctx context.Context) error {
+func (n *dockerNetwork) Close(ctx context.Context) error {
 	if n.pool == nil || n.pool.client == nil {
 		return ErrClientClosed
 	}
 
-	_, err := n.pool.client.NetworkRemove(ctx, n.Network.ID, mobyclient.NetworkRemoveOptions{})
+	_, err := n.pool.client.NetworkRemove(ctx, n.inspect.ID, mobyclient.NetworkRemoveOptions{})
 	if err != nil && !errdefs.IsNotFound(err) {
 		return err
 	}
 
-	n.pool.untrackNetwork(n.Network.ID)
+	n.pool.untrackNetwork(n.inspect.ID)
 	return nil
 }
 
 // CloseT removes the network and calls t.Fatalf on error.
-func (n *Network) CloseT(t TestingTB) {
+func (n *dockerNetwork) CloseT(t TestingTB) {
 	t.Helper()
 	if err := n.Close(context.WithoutCancel(t.Context())); err != nil {
 		t.Fatalf("CloseT failed: %v", err)
 	}
-}
-
-// ConnectToNetwork connects the container to the given network.
-// The resource's Container field is automatically updated with the latest
-// network settings after connection.
-func (r *Resource) ConnectToNetwork(ctx context.Context, net *Network) error {
-	if r.pool == nil || r.pool.client == nil {
-		return ErrClientClosed
-	}
-
-	connectOpts := mobyclient.NetworkConnectOptions{
-		Container: r.Container.ID,
-	}
-
-	_, err := r.pool.client.NetworkConnect(ctx, net.Network.ID, connectOpts)
-	if err != nil {
-		return err
-	}
-
-	// Refresh container inspection to get updated network settings
-	inspectResp, err := r.pool.client.ContainerInspect(ctx, r.Container.ID, mobyclient.ContainerInspectOptions{})
-	if err != nil {
-		return err
-	}
-
-	r.Container = inspectResp.Container
-	return nil
-}
-
-// DisconnectFromNetwork disconnects the container from the given network.
-// The resource's Container field is automatically updated with the latest
-// network settings after disconnection.
-func (r *Resource) DisconnectFromNetwork(ctx context.Context, net *Network) error {
-	if r.pool == nil || r.pool.client == nil {
-		return ErrClientClosed
-	}
-
-	disconnectOpts := mobyclient.NetworkDisconnectOptions{
-		Container: r.Container.ID,
-		Force:     false,
-	}
-
-	_, err := r.pool.client.NetworkDisconnect(ctx, net.Network.ID, disconnectOpts)
-	if err != nil {
-		return err
-	}
-
-	// Refresh container inspection to get updated network settings
-	inspectResp, err := r.pool.client.ContainerInspect(ctx, r.Container.ID, mobyclient.ContainerInspectOptions{})
-	if err != nil {
-		return err
-	}
-
-	r.Container = inspectResp.Container
-	return nil
-}
-
-// GetIPInNetwork returns the container's IP address in the given network.
-// Returns empty string if the container is not connected to the network.
-func (r *Resource) GetIPInNetwork(net *Network) string {
-	if r.Container.NetworkSettings == nil {
-		return ""
-	}
-
-	if r.Container.NetworkSettings.Networks == nil {
-		return ""
-	}
-
-	networkName := net.Network.Name
-	endpoint, ok := r.Container.NetworkSettings.Networks[networkName]
-	if !ok {
-		return ""
-	}
-
-	return endpoint.IPAddress.String()
 }

--- a/network_test.go
+++ b/network_test.go
@@ -26,11 +26,11 @@ func TestPoolCreateNetwork(t *testing.T) {
 			network.Close(t.Context())
 		})
 
-		if network.Network.Name != name {
-			t.Errorf("network.Network.Name = %q, want %q", network.Network.Name, name)
+		if network.Inspect().Name != name {
+			t.Errorf("network.Inspect().Name = %q, want %q", network.Inspect().Name, name)
 		}
-		if network.Network.ID == "" {
-			t.Error("network.Network.ID is empty, want non-empty")
+		if network.Inspect().ID == "" {
+			t.Error("network.Inspect().ID is empty, want non-empty")
 		}
 	})
 
@@ -53,11 +53,11 @@ func TestPoolCreateNetwork(t *testing.T) {
 			network.Close(t.Context())
 		})
 
-		if network.Network.Driver != "bridge" {
-			t.Errorf("network.Network.Driver = %q, want %q", network.Network.Driver, "bridge")
+		if network.Inspect().Driver != "bridge" {
+			t.Errorf("network.Inspect().Driver = %q, want %q", network.Inspect().Driver, "bridge")
 		}
-		if network.Network.Labels["test"] != "label" {
-			t.Errorf("network.Network.Labels[test] = %q, want %q", network.Network.Labels["test"], "label")
+		if network.Inspect().Labels["test"] != "label" {
+			t.Errorf("network.Inspect().Labels[test] = %q, want %q", network.Inspect().Labels["test"], "label")
 		}
 	})
 
@@ -73,8 +73,8 @@ func TestPoolCreateNetwork(t *testing.T) {
 			network.Close(t.Context())
 		})
 
-		if network.Network.Name != name {
-			t.Errorf("network.Network.Name = %q, want %q", network.Network.Name, name)
+		if network.Inspect().Name != name {
+			t.Errorf("network.Inspect().Name = %q, want %q", network.Inspect().Name, name)
 		}
 	})
 }
@@ -88,12 +88,9 @@ func TestPoolCreateNetworkT(t *testing.T) {
 		if network == nil {
 			t.Fatal("CreateNetworkT() network = nil, want non-nil")
 		}
-		t.Cleanup(func() {
-			network.Close(t.Context())
-		})
 
-		if network.Network.Name != name {
-			t.Errorf("network.Network.Name = %q, want %q", network.Network.Name, name)
+		if network.Inspect().Name != name {
+			t.Errorf("network.Inspect().Name = %q, want %q", network.Inspect().Name, name)
 		}
 	})
 }
@@ -102,9 +99,13 @@ func TestNetworkClose(t *testing.T) {
 	t.Run("removes network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
 		networkName := t.Name()
-		network := pool.CreateNetworkT(t, networkName, nil)
+		// Use CreateNetwork (non-T) to get raw ClosableNetwork for manual Close testing
+		network, err := pool.CreateNetwork(t.Context(), networkName, nil)
+		if err != nil {
+			t.Fatalf("CreateNetwork() error = %v, want nil", err)
+		}
 
-		err := network.Close(t.Context())
+		err = network.Close(t.Context())
 		if err != nil {
 			t.Fatalf("Close() error = %v, want nil", err)
 		}
@@ -122,10 +123,14 @@ func TestNetworkClose(t *testing.T) {
 
 func TestNetworkCloseIdempotent(t *testing.T) {
 	pool := dockertest.NewPoolT(t, "")
-	network := pool.CreateNetworkT(t, t.Name(), nil)
+	// Use CreateNetwork (non-T) to get raw ClosableNetwork for manual Close testing
+	network, err := pool.CreateNetwork(t.Context(), t.Name(), nil)
+	if err != nil {
+		t.Fatalf("CreateNetwork() error = %v, want nil", err)
+	}
 
 	// First close should succeed
-	err := network.Close(t.Context())
+	err = network.Close(t.Context())
 	if err != nil {
 		t.Fatalf("first Close() error = %v, want nil", err)
 	}
@@ -141,7 +146,11 @@ func TestNetworkCloseT(t *testing.T) {
 	t.Run("removes network using t.Context", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
 		name := t.Name()
-		network := pool.CreateNetworkT(t, name, nil)
+		// Use CreateNetwork (non-T) to get raw ClosableNetwork for manual CloseT testing
+		network, err := pool.CreateNetwork(t.Context(), name, nil)
+		if err != nil {
+			t.Fatalf("CreateNetwork() error = %v, want nil", err)
+		}
 
 		network.CloseT(t)
 
@@ -160,14 +169,8 @@ func TestResourceConnectToNetwork(t *testing.T) {
 	t.Run("connects container to network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
 		network := pool.CreateNetworkT(t, t.Name(), nil)
-		t.Cleanup(func() {
-			network.Close(t.Context())
-		})
 
 		resource := pool.RunT(t, "alpine", dockertest.WithTag("latest"), dockertest.WithCmd([]string{"sleep", "300"}), dockertest.WithoutReuse())
-		t.Cleanup(func() {
-			resource.Close(t.Context())
-		})
 
 		err := resource.ConnectToNetwork(t.Context(), network)
 		if err != nil {
@@ -186,14 +189,8 @@ func TestResourceDisconnectFromNetwork(t *testing.T) {
 	t.Run("disconnects container from network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
 		network := pool.CreateNetworkT(t, t.Name(), nil)
-		t.Cleanup(func() {
-			network.Close(t.Context())
-		})
 
 		resource := pool.RunT(t, "alpine", dockertest.WithTag("latest"), dockertest.WithCmd([]string{"sleep", "300"}), dockertest.WithoutReuse())
-		t.Cleanup(func() {
-			resource.Close(t.Context())
-		})
 
 		// First connect
 		err := resource.ConnectToNetwork(t.Context(), network)
@@ -225,14 +222,8 @@ func TestResourceGetIPInNetwork(t *testing.T) {
 	t.Run("returns IP in network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
 		network := pool.CreateNetworkT(t, t.Name(), nil)
-		t.Cleanup(func() {
-			network.Close(t.Context())
-		})
 
 		resource := pool.RunT(t, "alpine", dockertest.WithTag("latest"), dockertest.WithCmd([]string{"sleep", "300"}), dockertest.WithoutReuse())
-		t.Cleanup(func() {
-			resource.Close(t.Context())
-		})
 
 		err := resource.ConnectToNetwork(t.Context(), network)
 		if err != nil {
@@ -253,14 +244,8 @@ func TestResourceGetIPInNetwork(t *testing.T) {
 	t.Run("returns empty for non-connected network", func(t *testing.T) {
 		pool := dockertest.NewPoolT(t, "")
 		network := pool.CreateNetworkT(t, t.Name(), nil)
-		t.Cleanup(func() {
-			network.Close(t.Context())
-		})
 
 		resource := pool.RunT(t, "alpine", dockertest.WithTag("latest"), dockertest.WithCmd([]string{"sleep", "300"}), dockertest.WithoutReuse())
-		t.Cleanup(func() {
-			resource.Close(t.Context())
-		})
 
 		// Don't connect to network
 		ip := resource.GetIPInNetwork(network)
@@ -276,15 +261,9 @@ func TestNetworkIntegration(t *testing.T) {
 
 		// Create custom network
 		network := pool.CreateNetworkT(t, t.Name(), nil)
-		t.Cleanup(func() {
-			network.Close(t.Context())
-		})
 
 		// Start first container
 		resource1 := pool.RunT(t, "alpine", dockertest.WithTag("latest"), dockertest.WithCmd([]string{"sleep", "300"}), dockertest.WithoutReuse())
-		t.Cleanup(func() {
-			resource1.Close(t.Context())
-		})
 
 		// Connect to network
 		err := resource1.ConnectToNetwork(t.Context(), network)
@@ -294,9 +273,6 @@ func TestNetworkIntegration(t *testing.T) {
 
 		// Start second container
 		resource2 := pool.RunT(t, "alpine", dockertest.WithTag("latest"), dockertest.WithCmd([]string{"sleep", "300"}), dockertest.WithoutReuse())
-		t.Cleanup(func() {
-			resource2.Close(t.Context())
-		})
 
 		// Connect to network
 		err = resource2.ConnectToNetwork(t.Context(), network)

--- a/options.go
+++ b/options.go
@@ -11,22 +11,22 @@ import (
 	"github.com/ory/dockertest/v4/internal/client"
 )
 
-// PoolOption is a functional option for configuring a Pool.
-// Use with NewPool or NewPoolT to customize Pool behavior.
-type PoolOption func(*Pool)
+// PoolOption is a functional option for configuring a pool.
+// Use with NewPool or NewPoolT to customize pool behavior.
+type PoolOption func(*pool)
 
 // WithMaxWait sets the maximum wait time for operations.
-// The default MaxWait is 60 seconds.
+// The default maxWait is 60 seconds.
 func WithMaxWait(d time.Duration) PoolOption {
-	return func(p *Pool) {
-		p.MaxWait = d
+	return func(p *pool) {
+		p.maxWait = d
 	}
 }
 
 // WithMobyClient sets a custom Docker client.
-// When a custom client is provided, the Pool will not close it on Pool.Close().
+// When a custom client is provided, the pool will not close it on Close().
 func WithMobyClient(c client.DockerClient) PoolOption {
-	return func(p *Pool) {
+	return func(p *pool) {
 		p.client = c
 		p.ownedClient = false
 	}

--- a/pool.go
+++ b/pool.go
@@ -26,34 +26,46 @@ type TestingTB interface {
 	Fatalf(format string, args ...any)
 }
 
-// Pool manages Docker resources and operations.
-// It provides methods for running containers, building images, creating networks,
-// and managing the lifecycle of Docker resources in tests.
-//
-// A Pool instance owns a Docker client connection and manages resources through
-// that connection. Use NewPool or NewPoolT to create a Pool, and Close to clean up.
-type Pool struct {
-	client      client.DockerClient
-	ownedClient bool          // true if Pool created the client and should close it
-	MaxWait     time.Duration // maximum wait time for operations
-	reuseScope  string
-	resources   sync.Map
-	networks    sync.Map
+// Pool is the interface for managing Docker resources in tests.
+// Returned by NewPoolT; does not expose Close or CloseT.
+type Pool interface {
+	Run(ctx context.Context, repository string, opts ...RunOption) (ClosableResource, error)
+	RunT(t TestingTB, repository string, opts ...RunOption) Resource
+	BuildAndRun(ctx context.Context, name string, buildOpts *BuildOptions, runOpts ...RunOption) (ClosableResource, error)
+	BuildAndRunT(t TestingTB, name string, buildOpts *BuildOptions, runOpts ...RunOption) Resource
+	CreateNetwork(ctx context.Context, name string, opts *NetworkCreateOptions) (ClosableNetwork, error)
+	CreateNetworkT(t TestingTB, name string, opts *NetworkCreateOptions) Network
+	Retry(ctx context.Context, timeout time.Duration, fn func() error) error
+	Client() client.DockerClient
 }
 
-// NewPool creates a new Pool with the given endpoint and options.
+// ClosablePool extends Pool with explicit lifecycle management.
+// Returned by NewPool; the caller is responsible for calling Close.
+type ClosablePool interface {
+	Pool
+	Close(ctx context.Context) error
+	CloseT(t TestingTB)
+}
+
+// pool manages Docker resources and operations.
+type pool struct {
+	client      client.DockerClient
+	ownedClient bool   // true if pool created the client and should close it
+	daemonHost  string // Docker daemon endpoint; scopes the reuse registry
+	maxWait     time.Duration
+
+	mu        sync.Mutex
+	resources []*resource // each entry is one reference; reused containers appear once per acquisition
+	networks  sync.Map
+}
+
+// NewPool creates a new pool with the given endpoint and options.
 //
 // The endpoint parameter must be empty. The Docker client is created from
 // environment variables (DOCKER_HOST, DOCKER_TLS_VERIFY, DOCKER_CERT_PATH) or
 // provided via WithMobyClient option.
 //
-// To specify a custom Docker endpoint, set the DOCKER_HOST environment variable
-// before calling NewPool, or provide a custom client with WithMobyClient.
-//
-// The default MaxWait is 60 seconds. This can be customized with WithMaxWait.
-//
-// The Pool creates and owns a Docker client by default. Call Close when done
-// to release resources. If you need to provide your own client, use WithMobyClient.
+// The default maxWait is 60 seconds. This can be customized with WithMaxWait.
 //
 // Example:
 //
@@ -63,23 +75,20 @@ type Pool struct {
 //		panic(err)
 //	}
 //	defer pool.Close(ctx)
-func NewPool(ctx context.Context, endpoint string, opts ...PoolOption) (*Pool, error) {
-	p := &Pool{
-		MaxWait:     60 * time.Second,
+func NewPool(ctx context.Context, endpoint string, opts ...PoolOption) (ClosablePool, error) {
+	p := &pool{
+		maxWait:     60 * time.Second,
 		ownedClient: true,
 	}
 
-	// Apply options
 	for _, opt := range opts {
 		opt(p)
 	}
 
-	// Validate endpoint only if we need to create a client
 	if p.client == nil && endpoint != "" {
 		return nil, fmt.Errorf("endpoint parameter is not supported; use DOCKER_HOST environment variable or WithMobyClient option")
 	}
 
-	// Create client if not provided via options
 	if p.client == nil {
 		c, err := client.NewMobyClient(ctx)
 		if err != nil {
@@ -89,47 +98,58 @@ func NewPool(ctx context.Context, endpoint string, opts ...PoolOption) (*Pool, e
 		p.ownedClient = true
 	}
 
-	if p.ownedClient {
-		p.reuseScope = defaultRegistryScope
-	} else {
-		p.reuseScope = fmt.Sprintf("%p", p.client)
-	}
+	p.daemonHost = p.client.DaemonHost()
 
 	return p, nil
 }
 
-func (p *Pool) trackResource(resource *Resource) {
-	if resource == nil || resource.Container.ID == "" {
-		return
-	}
-	p.resources.Store(resource.Container.ID, resource)
+// Client returns the underlying Docker client.
+func (p *pool) Client() client.DockerClient {
+	return p.client
 }
 
-func (p *Pool) untrackResource(containerID string) {
+func (p *pool) trackResource(r *resource) {
+	if r == nil || r.container.ID == "" {
+		return
+	}
+	p.mu.Lock()
+	p.resources = append(p.resources, r)
+	p.mu.Unlock()
+}
+
+func (p *pool) untrackResource(containerID string) {
 	if containerID == "" {
 		return
 	}
-	p.resources.Delete(containerID)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Remove the first matching entry (preserves other refs to the same container).
+	for i, r := range p.resources {
+		if r.container.ID == containerID {
+			p.resources = append(p.resources[:i], p.resources[i+1:]...)
+			return
+		}
+	}
 }
 
-func (p *Pool) trackNetwork(net *Network) {
-	if net == nil || net.Network.ID == "" {
+func (p *pool) trackNetwork(net *dockerNetwork) {
+	if net == nil || net.inspect.ID == "" {
 		return
 	}
-	p.networks.Store(net.Network.ID, net)
+	p.networks.Store(net.inspect.ID, net)
 }
 
-func (p *Pool) untrackNetwork(networkID string) {
+func (p *pool) untrackNetwork(networkID string) {
 	if networkID == "" {
 		return
 	}
 	p.networks.Delete(networkID)
 }
 
-func (p *Pool) trackedNetworks() []*Network {
-	var networks []*Network
+func (p *pool) trackedNetworks() []*dockerNetwork {
+	var networks []*dockerNetwork
 	p.networks.Range(func(_, value any) bool {
-		net, ok := value.(*Network)
+		net, ok := value.(*dockerNetwork)
 		if ok {
 			networks = append(networks, net)
 		}
@@ -138,43 +158,41 @@ func (p *Pool) trackedNetworks() []*Network {
 	return networks
 }
 
-func (p *Pool) trackedResources() []*Resource {
-	var resources []*Resource
-	p.resources.Range(func(_, value any) bool {
-		resource, ok := value.(*Resource)
-		if ok {
-			resources = append(resources, resource)
-		}
-		return true
-	})
-	return resources
+func (p *pool) trackedResources() []*resource {
+	p.mu.Lock()
+	snapshot := make([]*resource, len(p.resources))
+	copy(snapshot, p.resources)
+	p.mu.Unlock()
+	return snapshot
 }
 
-// NewPoolT creates a new Pool using t.Context() and registers cleanup with t.Cleanup().
-func NewPoolT(t TestingTB, endpoint string, opts ...PoolOption) *Pool {
+// NewPoolT creates a new pool using t.Context() and registers cleanup with t.Cleanup().
+// The returned Pool does not expose Close or CloseT; the pool is automatically
+// cleaned up when the test finishes.
+func NewPoolT(t TestingTB, endpoint string, opts ...PoolOption) Pool {
 	t.Helper()
 
-	pool, err := NewPool(t.Context(), endpoint, opts...)
+	p, err := NewPool(t.Context(), endpoint, opts...)
 	if err != nil {
 		t.Fatalf("NewPool() error = %v", err)
 	}
 
 	t.Cleanup(func() {
-		if err := pool.Close(context.WithoutCancel(t.Context())); err != nil {
+		if err := p.Close(context.WithoutCancel(t.Context())); err != nil {
 			t.Logf("pool.Close() error: %v", err)
 		}
 	})
 
-	return pool
+	return p
 }
 
-// Close cleans up all tracked containers and networks, then closes the Pool's
-// Docker client if it was created by the Pool. If a custom client was provided
+// Close cleans up all tracked containers and networks, then closes the pool's
+// Docker client if it was created by the pool. If a custom client was provided
 // via WithMobyClient, it is not closed (the caller remains responsible for
 // closing it).
 //
 // It is safe to call Close multiple times.
-func (p *Pool) Close(ctx context.Context) error {
+func (p *pool) Close(ctx context.Context) error {
 	cleanupErr := p.cleanup(ctx)
 	if p.ownedClient && p.client != nil {
 		err := p.client.Close()
@@ -186,62 +204,38 @@ func (p *Pool) Close(ctx context.Context) error {
 	return cleanupErr
 }
 
-// CloseT cleans up all tracked containers and networks, then closes the Pool's
+// CloseT cleans up all tracked containers and networks, then closes the pool's
 // Docker client. It calls t.Fatalf on error.
-func (p *Pool) CloseT(t TestingTB) {
+func (p *pool) CloseT(t TestingTB) {
 	t.Helper()
 	if err := p.Close(context.WithoutCancel(t.Context())); err != nil {
 		t.Fatalf("Pool.CloseT failed: %v", err)
 	}
 }
 
-// cleanup removes all containers and networks tracked by this pool.
-// Containers are removed first, then networks. Errors during cleanup
-// do not stop the cleanup process. The first error encountered is returned.
-//
-// Unlike Resource.Close, cleanup force-removes containers regardless of
-// reference count. This ensures that Pool.Close fully cleans up even when
-// reused containers still have outstanding references.
-func (p *Pool) cleanup(ctx context.Context) error {
+// cleanup closes all tracked resources and networks.
+// Resources are closed first (respecting ref counts), then networks.
+// Errors during cleanup do not stop the process. The first error is returned.
+func (p *pool) cleanup(ctx context.Context) error {
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
 	defer cancel()
 
 	var firstErr error
 
-	// Force-remove containers (bypass ref counting — the pool is shutting down).
-	for _, resource := range p.trackedResources() {
-		if err := p.forceRemoveContainer(cleanupCtx, resource.Container.ID); err != nil && firstErr == nil {
+	for _, r := range p.trackedResources() {
+		if err := r.Close(cleanupCtx); err != nil && firstErr == nil {
 			firstErr = err
 		}
-		p.untrackResource(resource.Container.ID)
 	}
 
-	// Remove networks after containers are gone
 	for _, net := range p.trackedNetworks() {
 		if err := net.Close(cleanupCtx); err != nil && firstErr == nil {
 			firstErr = err
 		}
-		p.untrackNetwork(net.Network.ID)
-	}
-
-	if p.reuseScope != "" {
-		resetRegistryWithScope(p.reuseScope)
+		p.untrackNetwork(net.inspect.ID)
 	}
 
 	return firstErr
-}
-
-// forceRemoveContainer stops and removes a container, ignoring not-found errors.
-func (p *Pool) forceRemoveContainer(ctx context.Context, containerID string) error {
-	_, _ = p.client.ContainerStop(ctx, containerID, mobyclient.ContainerStopOptions{})
-	_, err := p.client.ContainerRemove(ctx, containerID, mobyclient.ContainerRemoveOptions{
-		RemoveVolumes: true,
-		Force:         true,
-	})
-	if err != nil && !errdefs.IsNotFound(err) {
-		return err
-	}
-	return nil
 }
 
 // Run starts a container with the given repository and options.
@@ -262,22 +256,7 @@ func (p *Pool) forceRemoveContainer(ctx context.Context, containerID string) err
 //		panic(err)
 //	}
 //	defer resource.Close(ctx)
-//
-// To disable reuse:
-//
-//	resource, err := pool.Run(ctx, "postgres",
-//		dockertest.WithTag("14"),
-//		dockertest.WithoutReuse(),
-//	)
-//
-// To use a custom reuse key:
-//
-//	resource, err := pool.Run(ctx, "postgres",
-//		dockertest.WithTag("14"),
-//		dockertest.WithEnv([]string{"POSTGRES_PASSWORD=secret"}),
-//		dockertest.WithReuseID("postgres-14-secret"),
-//	)
-func (p *Pool) Run(ctx context.Context, repository string, opts ...RunOption) (*Resource, error) {
+func (p *pool) Run(ctx context.Context, repository string, opts ...RunOption) (ClosableResource, error) {
 	cfg, err := buildRunConfig(opts)
 	if err != nil {
 		return nil, err
@@ -328,16 +307,22 @@ func computeReuseID(repository string, cfg *runConfig) string {
 	return fmt.Sprintf("%s:%s", repository, cfg.tag)
 }
 
+// registryKey returns a registry key scoped to this pool's daemon host.
+// This ensures that pools connected to different Docker daemons never
+// share containers through the global registry.
+func (p *pool) registryKey(reuseID string) string {
+	return p.daemonHost + "\x00" + reuseID
+}
+
 // checkForExisting looks up an existing container in the registry and
-// increments its reference count. The returned Resource is a shallow clone
+// increments its reference count. The returned resource is a shallow clone
 // of the canonical registry entry with the pool pointer updated to the
-// caller's pool. This is safe because Container (a value type) is copied,
-// and reuseID is an immutable string.
-func checkForExisting(p *Pool, reuseID string) *Resource {
+// caller's pool.
+func checkForExisting(p *pool, reuseID string) *resource {
 	if reuseID == "" {
 		return nil
 	}
-	if existing, ok := acquireWithScope(p.reuseScope, reuseID); ok {
+	if existing, ok := acquire(p.registryKey(reuseID)); ok {
 		cloned := *existing
 		cloned.pool = p
 		return &cloned
@@ -346,7 +331,7 @@ func checkForExisting(p *Pool, reuseID string) *Resource {
 }
 
 // pullImage pulls a Docker image unless noPull is set.
-func (p *Pool) pullImage(ctx context.Context, ref string, noPull bool) error {
+func (p *pool) pullImage(ctx context.Context, ref string, noPull bool) error {
 	if noPull {
 		return nil
 	}
@@ -365,8 +350,7 @@ func (p *Pool) pullImage(ctx context.Context, ref string, noPull bool) error {
 		_ = pullResp.Close() //nolint:errcheck // Best effort close in defer
 	}()
 
-	// Wait consumes the JSON stream and surfaces any errors embedded in it
-	// (e.g. "manifest not found", authentication failures).
+	// Wait consumes the JSON stream and surfaces any errors embedded in it.
 	if err := pullResp.Wait(ctx); err != nil {
 		return fmt.Errorf("%w: %s: %w", ErrImagePullFailed, ref, err)
 	}
@@ -375,7 +359,7 @@ func (p *Pool) pullImage(ctx context.Context, ref string, noPull bool) error {
 }
 
 // createAndStartContainer creates and starts a container with the given configuration.
-func (p *Pool) createAndStartContainer(ctx context.Context, ref string, cfg *runConfig) (string, error) {
+func (p *pool) createAndStartContainer(ctx context.Context, ref string, cfg *runConfig) (string, error) {
 	containerConfig := &container.Config{
 		Image:      ref,
 		Env:        cfg.env,
@@ -433,21 +417,21 @@ func (p *Pool) createAndStartContainer(ctx context.Context, ref string, cfg *run
 }
 
 // inspectAndRegister inspects the container and registers it in the global registry.
-func (p *Pool) inspectAndRegister(ctx context.Context, containerID, reuseID string) (*Resource, error) {
+func (p *pool) inspectAndRegister(ctx context.Context, containerID, reuseID string) (*resource, error) {
 	inspectResp, err := p.inspectWithPortRetry(ctx, containerID)
 	if err != nil {
 		_, _ = p.client.ContainerRemove(ctx, containerID, mobyclient.ContainerRemoveOptions{Force: true}) //nolint:errcheck // Best effort cleanup
 		return nil, fmt.Errorf("container inspect failed: %w", err)
 	}
 
-	resource := &Resource{
+	r := &resource{
 		pool:      p,
-		Container: inspectResp.Container,
+		container: inspectResp.Container,
 		reuseID:   reuseID,
 	}
 
 	if reuseID != "" {
-		canonical, loaded := registerWithScope(p.reuseScope, reuseID, resource)
+		canonical, loaded := register(p.registryKey(reuseID), r)
 		if loaded {
 			cleanupCtx := context.WithoutCancel(ctx)
 			_, _ = p.client.ContainerRemove(cleanupCtx, containerID, mobyclient.ContainerRemoveOptions{
@@ -457,21 +441,21 @@ func (p *Pool) inspectAndRegister(ctx context.Context, containerID, reuseID stri
 
 			cloned := *canonical
 			cloned.pool = p
-			resource = &cloned
+			r = &cloned
 		} else {
-			resource = canonical
+			r = canonical
 		}
 	}
 
-	p.trackResource(resource)
+	p.trackResource(r)
 
-	return resource, nil
+	return r, nil
 }
 
 // inspectWithPortRetry inspects a container, retrying briefly if exposed ports
 // have not yet been bound. Docker may report empty port bindings immediately
 // after ContainerStart; this mirrors v3's inspectContainerWithRetries behavior.
-func (p *Pool) inspectWithPortRetry(ctx context.Context, containerID string) (mobyclient.ContainerInspectResult, error) {
+func (p *pool) inspectWithPortRetry(ctx context.Context, containerID string) (mobyclient.ContainerInspectResult, error) {
 	const maxRetries = 5
 	const retryDelay = 100 * time.Millisecond
 
@@ -504,13 +488,17 @@ func (p *Pool) inspectWithPortRetry(ctx context.Context, containerID string) (mo
 }
 
 // RunT is a test helper that uses t.Context() and calls t.Fatalf on error.
-func (p *Pool) RunT(t TestingTB, repository string, opts ...RunOption) *Resource {
+// The returned Resource does not expose Close, CloseT, or Cleanup;
+// the resource is automatically cleaned up when the test finishes.
+func (p *pool) RunT(t TestingTB, repository string, opts ...RunOption) Resource {
 	t.Helper()
 
 	r, err := p.Run(t.Context(), repository, opts...)
 	if err != nil {
 		t.Fatalf("RunT failed: %v", err)
 	}
+
+	r.Cleanup(t)
 
 	return r
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -4,6 +4,7 @@
 package dockertest
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -16,37 +17,38 @@ import (
 func TestNewPool(t *testing.T) {
 	t.Run("creates pool with default options", func(t *testing.T) {
 		ctx := t.Context()
-		pool, err := NewPool(ctx, "")
+		p, err := NewPool(ctx, "")
 		if err != nil {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
-		if pool == nil {
+		if p == nil {
 			t.Fatal("NewPool() pool = nil, want non-nil")
 		}
 		t.Cleanup(func() {
-			pool.Close(t.Context())
+			p.Close(t.Context())
 		})
 
-		if pool.MaxWait != 60*time.Second {
-			t.Errorf("pool.MaxWait = %v, want %v", pool.MaxWait, 60*time.Second)
+		rawPool := p.(*pool)
+		if rawPool.maxWait != 60*time.Second {
+			t.Errorf("pool.maxWait = %v, want %v", rawPool.maxWait, 60*time.Second)
 		}
-		if pool.client == nil {
+		if rawPool.client == nil {
 			t.Error("pool.client = nil, want non-nil")
 		}
 	})
 
 	t.Run("creates pool with custom MaxWait", func(t *testing.T) {
 		ctx := t.Context()
-		pool, err := NewPool(ctx, "", WithMaxWait(30*time.Second))
+		p, err := NewPool(ctx, "", WithMaxWait(30*time.Second))
 		if err != nil {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
 		t.Cleanup(func() {
-			pool.Close(t.Context())
+			p.Close(t.Context())
 		})
 
-		if pool.MaxWait != 30*time.Second {
-			t.Errorf("pool.MaxWait = %v, want %v", pool.MaxWait, 30*time.Second)
+		if p.(*pool).maxWait != 30*time.Second {
+			t.Errorf("pool.maxWait = %v, want %v", p.(*pool).maxWait, 30*time.Second)
 		}
 	})
 
@@ -60,15 +62,15 @@ func TestNewPool(t *testing.T) {
 			customClient.Close()
 		})
 
-		pool, err := NewPool(ctx, "", WithMobyClient(customClient))
+		p, err := NewPool(ctx, "", WithMobyClient(customClient))
 		if err != nil {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
 		t.Cleanup(func() {
-			pool.Close(t.Context())
+			p.Close(t.Context())
 		})
 
-		if pool.client != customClient {
+		if p.(*pool).client != customClient {
 			t.Error("pool.client != customClient, want same client")
 		}
 	})
@@ -84,34 +86,34 @@ func TestNewPool(t *testing.T) {
 		})
 
 		// Use invalid endpoint - should not fail because custom client is used
-		pool, err := NewPool(ctx, "invalid://endpoint", WithMobyClient(customClient))
+		p, err := NewPool(ctx, "invalid://endpoint", WithMobyClient(customClient))
 		if err != nil {
 			t.Fatalf("NewPool() error = %v, want nil (custom client should bypass endpoint)", err)
 		}
 		t.Cleanup(func() {
-			pool.Close(t.Context())
+			p.Close(t.Context())
 		})
 	})
 }
 
 func TestNewPoolT(t *testing.T) {
 	t.Run("creates pool with t.Context and t.Cleanup", func(t *testing.T) {
-		pool := NewPoolT(t, "")
-		if pool == nil {
+		p := NewPoolT(t, "")
+		if p == nil {
 			t.Fatal("NewPoolT() pool = nil, want non-nil")
 		}
 
 		// t.Cleanup should be registered, so we can't test it directly
 		// but we can verify the pool is functional
-		if pool.client == nil {
-			t.Error("pool.client = nil, want non-nil")
+		if p.Client() == nil {
+			t.Error("pool.Client() = nil, want non-nil")
 		}
 	})
 
 	t.Run("accepts options", func(t *testing.T) {
-		pool := NewPoolT(t, "", WithMaxWait(45*time.Second))
-		if pool.MaxWait != 45*time.Second {
-			t.Errorf("pool.MaxWait = %v, want %v", pool.MaxWait, 45*time.Second)
+		p := NewPoolT(t, "", WithMaxWait(45*time.Second))
+		if p.(*pool).maxWait != 45*time.Second {
+			t.Errorf("pool.maxWait = %v, want %v", p.(*pool).maxWait, 45*time.Second)
 		}
 	})
 }
@@ -119,12 +121,12 @@ func TestNewPoolT(t *testing.T) {
 func TestPoolClose(t *testing.T) {
 	t.Run("closes client", func(t *testing.T) {
 		ctx := t.Context()
-		pool, err := NewPool(ctx, "")
+		p, err := NewPool(ctx, "")
 		if err != nil {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
 
-		err = pool.Close(ctx)
+		err = p.Close(ctx)
 		if err != nil {
 			t.Errorf("Close() error = %v, want nil", err)
 		}
@@ -140,13 +142,13 @@ func TestPoolClose(t *testing.T) {
 			customClient.Close()
 		})
 
-		pool, err := NewPool(ctx, "", WithMobyClient(customClient))
+		p, err := NewPool(ctx, "", WithMobyClient(customClient))
 		if err != nil {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
 
 		// Close pool - should not close custom client
-		err = pool.Close(ctx)
+		err = p.Close(ctx)
 		if err != nil {
 			t.Errorf("Close() error = %v, want nil", err)
 		}
@@ -163,83 +165,46 @@ func TestPoolCleanup(t *testing.T) {
 	t.Run("cleanup with empty registry", func(t *testing.T) {
 		ResetRegistry()
 		ctx := t.Context()
-		pool, err := NewPool(ctx, "")
+		p, err := NewPool(ctx, "")
 		if err != nil {
 			t.Fatalf("NewPool() error = %v, want nil", err)
 		}
 		t.Cleanup(func() {
-			pool.Close(t.Context())
+			p.Close(t.Context())
 		})
 
-		err = pool.cleanup(ctx)
+		err = p.(*pool).cleanup(ctx)
 		if err != nil {
 			t.Errorf("cleanup() error = %v, want nil", err)
 		}
 	})
 }
 
-func TestCheckForExistingUsesPoolScope(t *testing.T) {
+func TestCheckForExistingIncrementsRefCount(t *testing.T) {
 	ResetRegistry()
 
-	resource := &Resource{Container: container.InspectResponse{ID: "scoped-container"}}
-	_, _ = registerWithScope("scope-a", "reuse-id", resource)
+	res := &resource{container: container.InspectResponse{ID: "ref-count-check"}}
+	p := &pool{daemonHost: "test-host"}
 
-	poolA := &Pool{reuseScope: "scope-a"}
-	if got := checkForExisting(poolA, "reuse-id"); got == nil || got.ID() != "scoped-container" {
-		t.Fatalf("checkForExisting(scope-a) = %#v, want container scoped-container", got)
+	// Pre-register with the pool's scoped key: refs=1
+	register(p.registryKey("id"), res)
+
+	// checkForExisting calls acquire with the same scoped key: refs=2
+	got := checkForExisting(p, "id")
+	if got == nil || got.ID() != res.ID() {
+		t.Fatalf("checkForExisting returned %v, want resource %q", got, res.ID())
 	}
 
-	poolB := &Pool{reuseScope: "scope-b"}
-	if got := checkForExisting(poolB, "reuse-id"); got != nil {
-		t.Fatalf("checkForExisting(scope-b) = %#v, want nil", got)
-	}
-}
+	key := p.registryKey("id")
 
-func TestDefaultPoolsShareReuseScope(t *testing.T) {
-	ctx := t.Context()
-	poolA, err := NewPool(ctx, "")
-	if err != nil {
-		t.Fatalf("NewPool() error = %v", err)
-	}
-	t.Cleanup(func() { poolA.Close(t.Context()) })
-
-	poolB, err := NewPool(ctx, "")
-	if err != nil {
-		t.Fatalf("NewPool() error = %v", err)
-	}
-	t.Cleanup(func() { poolB.Close(t.Context()) })
-
-	if poolA.reuseScope != poolB.reuseScope {
-		t.Fatalf("default pools have different reuse scopes: %q vs %q", poolA.reuseScope, poolB.reuseScope)
+	// First release: refs=1, not last
+	if release(key) {
+		t.Fatal("first release was last, want false")
 	}
 
-	if poolA.reuseScope != defaultRegistryScope {
-		t.Fatalf("default pool reuse scope = %q, want %q", poolA.reuseScope, defaultRegistryScope)
-	}
-}
-
-func TestCustomClientPoolHasIsolatedScope(t *testing.T) {
-	ctx := t.Context()
-	customClient, err := client.NewMobyClient(ctx)
-	if err != nil {
-		t.Fatalf("NewMobyClient() error = %v", err)
-	}
-	t.Cleanup(func() { customClient.Close() })
-
-	poolCustom, err := NewPool(ctx, "", WithMobyClient(customClient))
-	if err != nil {
-		t.Fatalf("NewPool() error = %v", err)
-	}
-	t.Cleanup(func() { poolCustom.Close(t.Context()) })
-
-	poolDefault, err := NewPool(ctx, "")
-	if err != nil {
-		t.Fatalf("NewPool() error = %v", err)
-	}
-	t.Cleanup(func() { poolDefault.Close(t.Context()) })
-
-	if poolCustom.reuseScope == poolDefault.reuseScope {
-		t.Fatal("custom client pool should have isolated reuse scope from default pool")
+	// Second release: refs=0, last
+	if !release(key) {
+		t.Fatal("second release was not last, want true")
 	}
 }
 
@@ -253,15 +218,18 @@ func TestPoolCloseT(t *testing.T) {
 		ResetRegistry()
 	})
 
-	pool := NewPoolT(t, "")
-	resource := pool.RunT(t, "alpine",
+	p, err := NewPool(t.Context(), "")
+	if err != nil {
+		t.Fatalf("NewPool() error = %v", err)
+	}
+	res := p.RunT(t, "alpine",
 		WithTag("latest"),
 		WithCmd([]string{"sleep", "300"}),
 		WithoutReuse(),
 	)
-	containerID := resource.ID()
+	containerID := res.ID()
 
-	pool.CloseT(t)
+	p.CloseT(t)
 
 	// After CloseT, the container should be removed
 	newPool, err := NewPool(t.Context(), "")
@@ -270,38 +238,13 @@ func TestPoolCloseT(t *testing.T) {
 	}
 	t.Cleanup(func() { newPool.Close(t.Context()) })
 
-	_, inspectErr := newPool.client.ContainerInspect(t.Context(), containerID, mobyclient.ContainerInspectOptions{})
+	_, inspectErr := newPool.(*pool).client.ContainerInspect(t.Context(), containerID, mobyclient.ContainerInspectOptions{})
 	if !errdefs.IsNotFound(inspectErr) {
 		t.Fatalf("ContainerInspect() error = %v, want not found", inspectErr)
 	}
 }
 
-func TestCheckForExistingIncrementsRefCount(t *testing.T) {
-	ResetRegistry()
-
-	resource := &Resource{Container: container.InspectResponse{ID: "ref-count-check"}}
-	// Register: refs=1
-	registerWithScope("scope", "id", resource)
-
-	pool := &Pool{reuseScope: "scope"}
-	// checkForExisting calls acquireWithScope: refs=2
-	got := checkForExisting(pool, "id")
-	if got == nil || got.ID() != resource.ID() {
-		t.Fatalf("checkForExisting returned %v, want resource %q", got, resource.ID())
-	}
-
-	// First release: refs=1, not last
-	if releaseWithScope("scope", "id") {
-		t.Fatal("first releaseWithScope was last, want false")
-	}
-
-	// Second release: refs=0, last
-	if !releaseWithScope("scope", "id") {
-		t.Fatal("second releaseWithScope was not last, want true")
-	}
-}
-
-func TestPoolCleanupForceRemovesReusedContainers(t *testing.T) {
+func TestPoolCleanupReleasesReusedContainers(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -311,41 +254,58 @@ func TestPoolCleanupForceRemovesReusedContainers(t *testing.T) {
 		ResetRegistry()
 	})
 
-	pool := NewPoolT(t, "")
+	ctx := t.Context()
+	p, err := NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("NewPool() error = %v", err)
+	}
 
 	// Run first reused container: refs=1
-	r1 := pool.RunT(t, "alpine",
+	r1, err := p.Run(ctx, "alpine",
 		WithTag("latest"),
 		WithCmd([]string{"sleep", "300"}),
 	)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
 
 	// Run second reused container (same repo:tag): refs=2
-	r2 := pool.RunT(t, "alpine",
+	r2, err := p.Run(ctx, "alpine",
 		WithTag("latest"),
 		WithCmd([]string{"sleep", "300"}),
 	)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
 
 	if r1.ID() != r2.ID() {
 		t.Fatalf("expected same container ID, got %s and %s", r1.ID(), r2.ID())
 	}
 
 	containerID := r1.ID()
-	reuseScope := pool.reuseScope
 
-	// cleanup() should force-remove everything regardless of ref count
-	if err := pool.cleanup(t.Context()); err != nil {
+	rawPool := p.(*pool)
+
+	// cleanup() should close both tracked resources, releasing all refs
+	if err := rawPool.cleanup(ctx); err != nil {
 		t.Fatalf("cleanup() error = %v", err)
 	}
 
-	// Container should be gone from Docker
-	_, err := pool.client.ContainerInspect(t.Context(), containerID, mobyclient.ContainerInspectOptions{})
+	// Container should be gone from Docker (both refs released)
+	_, err = rawPool.client.ContainerInspect(ctx, containerID, mobyclient.ContainerInspectOptions{})
 	if !errdefs.IsNotFound(err) {
 		t.Fatalf("ContainerInspect() error = %v, want not found", err)
 	}
 
 	// Registry entry should be cleared
-	if _, ok := getWithScope(reuseScope, "alpine:latest"); ok {
+	if _, ok := get(rawPool.registryKey("alpine:latest")); ok {
 		t.Fatal("registry entry still present after cleanup, want it removed")
+	}
+
+	// Close just the client (cleanup already done)
+	if rawPool.ownedClient && rawPool.client != nil {
+		rawPool.client.Close()
+		rawPool.client = nil
 	}
 }
 
@@ -359,19 +319,181 @@ func TestPoolCleanupRemovesWithoutReuse(t *testing.T) {
 		ResetRegistry()
 	})
 
-	pool := NewPoolT(t, "")
-	resource := pool.RunT(t, "alpine",
+	ctx := t.Context()
+	p, err := NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("NewPool() error = %v", err)
+	}
+	r, err := p.Run(ctx, "alpine",
 		WithTag("latest"),
 		WithCmd([]string{"sleep", "300"}),
 		WithoutReuse(),
 	)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
 
-	if err := pool.cleanup(t.Context()); err != nil {
+	containerID := r.ID()
+
+	rawPool := p.(*pool)
+	if err := rawPool.cleanup(ctx); err != nil {
 		t.Fatalf("cleanup() error = %v", err)
 	}
 
-	_, err := pool.client.ContainerInspect(t.Context(), resource.ID(), mobyclient.ContainerInspectOptions{})
+	_, err = rawPool.client.ContainerInspect(ctx, containerID, mobyclient.ContainerInspectOptions{})
 	if !errdefs.IsNotFound(err) {
 		t.Fatalf("ContainerInspect() error = %v, want not found", err)
+	}
+
+	if rawPool.ownedClient && rawPool.client != nil {
+		rawPool.client.Close()
+		rawPool.client = nil
+	}
+}
+
+func TestTwoPoolsShareReusedContainer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ResetRegistry()
+	t.Cleanup(func() {
+		ResetRegistry()
+	})
+
+	ctx := t.Context()
+
+	poolA, err := NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("NewPool(A) error = %v", err)
+	}
+
+	poolB, err := NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("NewPool(B) error = %v", err)
+	}
+
+	// Pool A runs alpine: refs=1
+	rA, err := poolA.Run(ctx, "alpine",
+		WithTag("latest"),
+		WithCmd([]string{"sleep", "300"}),
+	)
+	if err != nil {
+		t.Fatalf("poolA.Run() error = %v", err)
+	}
+
+	// Pool B runs alpine: refs=2 (same container)
+	rB, err := poolB.Run(ctx, "alpine",
+		WithTag("latest"),
+		WithCmd([]string{"sleep", "300"}),
+	)
+	if err != nil {
+		t.Fatalf("poolB.Run() error = %v", err)
+	}
+
+	if rA.ID() != rB.ID() {
+		t.Fatalf("expected same container ID across pools, got %s and %s", rA.ID(), rB.ID())
+	}
+
+	containerID := rA.ID()
+
+	// Close pool A: refs=1, container should still be alive
+	if err := poolA.Close(ctx); err != nil {
+		t.Fatalf("poolA.Close() error = %v", err)
+	}
+
+	_, err = poolB.(*pool).client.ContainerInspect(ctx, containerID, mobyclient.ContainerInspectOptions{})
+	if err != nil {
+		t.Fatalf("ContainerInspect() after closing pool A: error = %v, want container still alive", err)
+	}
+
+	// Close pool B: refs=0, container should be removed
+	if err := poolB.Close(ctx); err != nil {
+		t.Fatalf("poolB.Close() error = %v", err)
+	}
+
+	// Need a fresh client to inspect since both pools are closed
+	dc, err := client.NewMobyClient(ctx)
+	if err != nil {
+		t.Fatalf("NewMobyClient() error = %v", err)
+	}
+	t.Cleanup(func() { dc.Close() })
+
+	_, err = dc.ContainerInspect(ctx, containerID, mobyclient.ContainerInspectOptions{})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("ContainerInspect() after closing pool B: error = %v, want not found", err)
+	}
+}
+
+func TestResourceDoubleClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ResetRegistry()
+	t.Cleanup(func() {
+		ResetRegistry()
+	})
+
+	ctx := t.Context()
+	p, err := NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("NewPool() error = %v", err)
+	}
+	t.Cleanup(func() { p.Close(context.WithoutCancel(t.Context())) })
+
+	r, err := p.Run(ctx, "alpine",
+		WithTag("latest"),
+		WithCmd([]string{"sleep", "300"}),
+		WithoutReuse(),
+	)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// First close should succeed
+	if err := r.Close(ctx); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+
+	// Second close should not panic or error
+	if err := r.Close(ctx); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func TestPoolCloseAfterResourceClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ResetRegistry()
+	t.Cleanup(func() {
+		ResetRegistry()
+	})
+
+	ctx := t.Context()
+	p, err := NewPool(ctx, "")
+	if err != nil {
+		t.Fatalf("NewPool() error = %v", err)
+	}
+
+	r, err := p.Run(ctx, "alpine",
+		WithTag("latest"),
+		WithCmd([]string{"sleep", "300"}),
+		WithoutReuse(),
+	)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Close resource manually first
+	if err := r.Close(ctx); err != nil {
+		t.Fatalf("resource.Close() error = %v", err)
+	}
+
+	// Then close pool — should not error
+	if err := p.Close(ctx); err != nil {
+		t.Fatalf("pool.Close() error = %v", err)
 	}
 }

--- a/registry.go
+++ b/registry.go
@@ -11,35 +11,38 @@ import (
 	"github.com/moby/moby/api/types/container"
 )
 
-// Resource represents a Docker container managed by dockertest.
-// It provides methods for interacting with the container (getting ports, closing, etc.)
-// and accessing the underlying Docker container details.
-type Resource struct {
-	pool      *Pool
-	Container container.InspectResponse
+// resource represents a Docker container managed by dockertest.
+// It implements both Resource and ClosableResource interfaces.
+type resource struct {
+	pool      *pool
+	container container.InspectResponse
 	reuseID   string
 }
 
+// Container returns the Docker container inspection response.
+func (r *resource) Container() container.InspectResponse {
+	return r.container
+}
+
 // ID returns the container ID.
-func (r *Resource) ID() string {
-	return r.Container.ID
+func (r *resource) ID() string {
+	return r.container.ID
 }
 
-type registryKey struct {
-	scope   string
-	reuseID string
+// NewResource creates a Resource for testing purposes.
+// This is intended for unit tests that need a Resource without a Docker container.
+func NewResource(c container.InspectResponse) ClosableResource {
+	return &resource{container: c}
 }
 
-// registryEntry wraps a Resource with an atomic reference count.
+// registryEntry wraps a resource with an atomic reference count.
 // When multiple callers share a reused container, the ref count tracks
 // how many are still using it. The container is only removed from Docker
 // when the last reference is released.
 type registryEntry struct {
-	resource *Resource
+	resource *resource
 	refs     atomic.Int32
 }
-
-const defaultRegistryScope = "default"
 
 // globalRegistry is the package-level container registry using sync.Map for thread-safety.
 var globalRegistry sync.Map
@@ -57,14 +60,18 @@ var globalRegistry sync.Map
 //
 // Note: This function is called automatically by Pool.Run when container reuse
 // is enabled. You typically don't need to call it directly.
-func Register(reuseID string, r *Resource) error {
+func Register(reuseID string, r ClosableResource) error {
 	if reuseID == "" {
 		return fmt.Errorf("reuseID cannot be empty")
 	}
 	if r == nil {
 		return fmt.Errorf("resource cannot be nil")
 	}
-	_, _ = registerWithScope(defaultRegistryScope, reuseID, r)
+	res, ok := r.(*resource)
+	if !ok {
+		return fmt.Errorf("resource must be created by this package")
+	}
+	_, _ = register(reuseID, res)
 	return nil
 }
 
@@ -76,8 +83,12 @@ func Register(reuseID string, r *Resource) error {
 //
 // Note: This function is called automatically by Pool.Run when checking for
 // existing containers. You typically don't need to call it directly.
-func Get(reuseID string) (*Resource, bool) {
-	return getWithScope(defaultRegistryScope, reuseID)
+func Get(reuseID string) (ClosableResource, bool) {
+	r, ok := get(reuseID)
+	if !ok {
+		return nil, false
+	}
+	return r, true
 }
 
 // GetAll returns a slice of all resources in the global registry.
@@ -91,15 +102,19 @@ func Get(reuseID string) (*Resource, bool) {
 //		}
 //		dockertest.ResetRegistry()
 //	}
-func GetAll() []*Resource {
-	return getAllWithScope(defaultRegistryScope)
+func GetAll() []ClosableResource {
+	internal := getAll()
+	result := make([]ClosableResource, len(internal))
+	for i, r := range internal {
+		result[i] = r
+	}
+	return result
 }
 
-func registerWithScope(scope, reuseID string, r *Resource) (*Resource, bool) {
-	key := registryKey{scope: scope, reuseID: reuseID}
+func register(reuseID string, r *resource) (*resource, bool) {
 	entry := &registryEntry{resource: r}
 	entry.refs.Store(1)
-	actual, loaded := globalRegistry.LoadOrStore(key, entry)
+	actual, loaded := globalRegistry.LoadOrStore(reuseID, entry)
 	existing, ok := actual.(*registryEntry)
 	if !ok {
 		return r, loaded
@@ -111,11 +126,10 @@ func registerWithScope(scope, reuseID string, r *Resource) (*Resource, bool) {
 	return existing.resource, false
 }
 
-// acquireWithScope looks up an existing entry and increments its ref count.
+// acquire looks up an existing entry and increments its ref count.
 // Returns the resource and true if found, nil and false otherwise.
-func acquireWithScope(scope, reuseID string) (*Resource, bool) {
-	key := registryKey{scope: scope, reuseID: reuseID}
-	val, ok := globalRegistry.Load(key)
+func acquire(reuseID string) (*resource, bool) {
+	val, ok := globalRegistry.Load(reuseID)
 	if !ok {
 		return nil, false
 	}
@@ -125,35 +139,34 @@ func acquireWithScope(scope, reuseID string) (*Resource, bool) {
 	}
 	entry.refs.Add(1)
 	// Verify the entry is still in the map (not deleted and replaced between Load and Add).
-	if current, ok := globalRegistry.Load(key); !ok || current != val {
+	if current, ok := globalRegistry.Load(reuseID); !ok || current != val {
 		entry.refs.Add(-1)
 		return nil, false
 	}
 	return entry.resource, true
 }
 
-// releaseWithScope decrements the reference count for the given reuseID.
+// release decrements the reference count for the given reuseID.
 // Returns true if this was the last reference (caller should remove the container).
-func releaseWithScope(scope, reuseID string) bool {
-	key := registryKey{scope: scope, reuseID: reuseID}
-	val, ok := globalRegistry.Load(key)
+func release(reuseID string) bool {
+	val, ok := globalRegistry.Load(reuseID)
 	if !ok {
 		return true // Not found, treat as last reference
 	}
 	entry, ok := val.(*registryEntry)
 	if !ok {
-		globalRegistry.Delete(key)
+		globalRegistry.Delete(reuseID)
 		return true
 	}
 	if entry.refs.Add(-1) <= 0 {
-		globalRegistry.Delete(key)
+		globalRegistry.Delete(reuseID)
 		return true
 	}
 	return false
 }
 
-func getWithScope(scope, reuseID string) (*Resource, bool) {
-	val, ok := globalRegistry.Load(registryKey{scope: scope, reuseID: reuseID})
+func get(reuseID string) (*resource, bool) {
+	val, ok := globalRegistry.Load(reuseID)
 	if !ok {
 		return nil, false
 	}
@@ -164,14 +177,10 @@ func getWithScope(scope, reuseID string) (*Resource, bool) {
 	return entry.resource, true
 }
 
-func getAllWithScope(scope string) []*Resource {
-	var resources []*Resource
+func getAll() []*resource {
+	var resources []*resource
 
-	globalRegistry.Range(func(key, value any) bool {
-		regKey, ok := key.(registryKey)
-		if !ok || regKey.scope != scope {
-			return true
-		}
+	globalRegistry.Range(func(_, value any) bool {
 		if entry, ok := value.(*registryEntry); ok {
 			resources = append(resources, entry.resource)
 		}
@@ -179,21 +188,6 @@ func getAllWithScope(scope string) []*Resource {
 	})
 
 	return resources
-}
-
-func resetRegistryWithScope(scope string) {
-	var keys []registryKey
-	globalRegistry.Range(func(key, _ any) bool {
-		regKey, ok := key.(registryKey)
-		if ok && regKey.scope == scope {
-			keys = append(keys, regKey)
-		}
-		return true
-	})
-
-	for _, key := range keys {
-		globalRegistry.Delete(key)
-	}
 }
 
 // ResetRegistry clears all resources from the global registry.

--- a/registry_test.go
+++ b/registry_test.go
@@ -17,7 +17,7 @@ func TestRegistry(t *testing.T) {
 	t.Run("Register and Get", func(t *testing.T) {
 		ResetRegistry()
 
-		r1 := &Resource{Container: container.InspectResponse{ID: "container-1"}}
+		r1 := &resource{container: container.InspectResponse{ID: "container-1"}}
 
 		// Register a resource
 		err := Register("reuse-1", r1)
@@ -30,8 +30,8 @@ func TestRegistry(t *testing.T) {
 		if !ok {
 			t.Fatal("Get() ok = false, want true")
 		}
-		if got.Container.ID != r1.Container.ID {
-			t.Errorf("Get() ID = %v, want %v", got.Container.ID, r1.Container.ID)
+		if got.Container().ID != r1.Container().ID {
+			t.Errorf("Get() ID = %v, want %v", got.Container().ID, r1.Container().ID)
 		}
 	})
 
@@ -47,8 +47,8 @@ func TestRegistry(t *testing.T) {
 	t.Run("Register duplicate reuseID", func(t *testing.T) {
 		ResetRegistry()
 
-		r1 := &Resource{Container: container.InspectResponse{ID: "container-1"}}
-		r2 := &Resource{Container: container.InspectResponse{ID: "container-2"}}
+		r1 := &resource{container: container.InspectResponse{ID: "container-1"}}
+		r2 := &resource{container: container.InspectResponse{ID: "container-2"}}
 
 		// Register first resource
 		err := Register("reuse-1", r1)
@@ -75,9 +75,9 @@ func TestRegistry(t *testing.T) {
 	t.Run("GetAll returns all resources", func(t *testing.T) {
 		ResetRegistry()
 
-		r1 := &Resource{Container: container.InspectResponse{ID: "container-1"}}
-		r2 := &Resource{Container: container.InspectResponse{ID: "container-2"}}
-		r3 := &Resource{Container: container.InspectResponse{ID: "container-3"}}
+		r1 := &resource{container: container.InspectResponse{ID: "container-1"}}
+		r2 := &resource{container: container.InspectResponse{ID: "container-2"}}
+		r3 := &resource{container: container.InspectResponse{ID: "container-3"}}
 
 		Register("reuse-1", r1)
 		Register("reuse-2", r2)
@@ -91,7 +91,7 @@ func TestRegistry(t *testing.T) {
 		// Verify all resources are present
 		ids := make(map[string]bool)
 		for _, r := range all {
-			ids[r.Container.ID] = true
+			ids[r.Container().ID] = true
 		}
 
 		if !ids["container-1"] || !ids["container-2"] || !ids["container-3"] {
@@ -102,7 +102,7 @@ func TestRegistry(t *testing.T) {
 	t.Run("ResetRegistry clears all resources", func(t *testing.T) {
 		ResetRegistry()
 
-		r1 := &Resource{Container: container.InspectResponse{ID: "container-1"}}
+		r1 := &resource{container: container.InspectResponse{ID: "container-1"}}
 		Register("reuse-1", r1)
 
 		// Verify resource exists
@@ -140,7 +140,7 @@ func TestRegistryConcurrency(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		go func(id int) {
 			defer wg.Done()
-			r := &Resource{Container: container.InspectResponse{ID: "container-" + string(rune(id))}}
+			r := &resource{container: container.InspectResponse{ID: "container-" + string(rune(id))}}
 			Register(reuseID, r)
 		}(i)
 	}
@@ -163,57 +163,23 @@ func TestRegistryConcurrency(t *testing.T) {
 	}
 }
 
-func TestRegistryScopes(t *testing.T) {
+func TestRegisterLoadOrStore(t *testing.T) {
 	ResetRegistry()
 
-	r1 := &Resource{Container: container.InspectResponse{ID: "scope-a-container"}}
-	r2 := &Resource{Container: container.InspectResponse{ID: "scope-b-container"}}
+	first := &resource{container: container.InspectResponse{ID: "first"}}
+	second := &resource{container: container.InspectResponse{ID: "second"}}
 
-	_, loadedA := registerWithScope("scope-a", "same-reuse-id", r1)
-	if loadedA {
-		t.Fatal("registerWithScope(scope-a) loaded = true, want false")
-	}
-	_, loadedB := registerWithScope("scope-b", "same-reuse-id", r2)
-	if loadedB {
-		t.Fatal("registerWithScope(scope-b) loaded = true, want false")
-	}
-
-	gotA, okA := getWithScope("scope-a", "same-reuse-id")
-	if !okA || gotA.ID() != "scope-a-container" {
-		t.Fatalf("scope-a lookup failed: ok=%v id=%v", okA, gotA)
-	}
-
-	gotB, okB := getWithScope("scope-b", "same-reuse-id")
-	if !okB || gotB.ID() != "scope-b-container" {
-		t.Fatalf("scope-b lookup failed: ok=%v id=%v", okB, gotB)
-	}
-
-	resetRegistryWithScope("scope-a")
-	if _, ok := getWithScope("scope-a", "same-reuse-id"); ok {
-		t.Fatal("scope-a entry still present after resetRegistryWithScope")
-	}
-	if _, ok := getWithScope("scope-b", "same-reuse-id"); !ok {
-		t.Fatal("scope-b entry unexpectedly removed by scope-a reset")
-	}
-}
-
-func TestRegisterWithScopeLoadOrStore(t *testing.T) {
-	ResetRegistry()
-
-	first := &Resource{Container: container.InspectResponse{ID: "first"}}
-	second := &Resource{Container: container.InspectResponse{ID: "second"}}
-
-	stored, loaded := registerWithScope("scope", "reuse", first)
+	stored, loaded := register("reuse", first)
 	if loaded {
-		t.Fatal("first registerWithScope call loaded = true, want false")
+		t.Fatal("first register call loaded = true, want false")
 	}
 	if stored.ID() != first.ID() {
 		t.Fatalf("first stored resource = %q, want %q", stored.ID(), first.ID())
 	}
 
-	stored, loaded = registerWithScope("scope", "reuse", second)
+	stored, loaded = register("reuse", second)
 	if !loaded {
-		t.Fatal("second registerWithScope call loaded = false, want true")
+		t.Fatal("second register call loaded = false, want true")
 	}
 	if stored.ID() != first.ID() {
 		t.Fatalf("second stored resource = %q, want %q", stored.ID(), first.ID())
@@ -223,38 +189,38 @@ func TestRegisterWithScopeLoadOrStore(t *testing.T) {
 func TestRegistryRefCounting(t *testing.T) {
 	ResetRegistry()
 
-	r := &Resource{Container: container.InspectResponse{ID: "refcount-container"}}
+	r := &resource{container: container.InspectResponse{ID: "refcount-container"}}
 
 	// Register: refs=1
-	_, loaded := registerWithScope("scope", "rc-id", r)
+	_, loaded := register("rc-id", r)
 	if loaded {
 		t.Fatal("first register loaded = true, want false")
 	}
 
 	// Acquire: refs=2
-	got, ok := acquireWithScope("scope", "rc-id")
+	got, ok := acquire("rc-id")
 	if !ok {
-		t.Fatal("acquireWithScope returned false, want true")
+		t.Fatal("acquire returned false, want true")
 	}
 	if got.ID() != r.ID() {
-		t.Fatalf("acquireWithScope returned %q, want %q", got.ID(), r.ID())
+		t.Fatalf("acquire returned %q, want %q", got.ID(), r.ID())
 	}
 
 	// Release once: refs=1, should NOT be last
-	if releaseWithScope("scope", "rc-id") {
-		t.Fatal("first releaseWithScope returned true (last ref), want false")
+	if release("rc-id") {
+		t.Fatal("first release returned true (last ref), want false")
 	}
 	// Entry should still exist
-	if _, ok := getWithScope("scope", "rc-id"); !ok {
+	if _, ok := get("rc-id"); !ok {
 		t.Fatal("entry removed after first release, want it to remain")
 	}
 
 	// Release again: refs=0, should be last
-	if !releaseWithScope("scope", "rc-id") {
-		t.Fatal("second releaseWithScope returned false, want true (last ref)")
+	if !release("rc-id") {
+		t.Fatal("second release returned false, want true (last ref)")
 	}
 	// Entry should be gone
-	if _, ok := getWithScope("scope", "rc-id"); ok {
+	if _, ok := get("rc-id"); ok {
 		t.Fatal("entry still present after last release, want it removed")
 	}
 }
@@ -262,13 +228,13 @@ func TestRegistryRefCounting(t *testing.T) {
 func TestRegistryRefCountingRegisterIncrementsOnDuplicate(t *testing.T) {
 	ResetRegistry()
 
-	r1 := &Resource{Container: container.InspectResponse{ID: "dup-1"}}
-	r2 := &Resource{Container: container.InspectResponse{ID: "dup-2"}}
+	r1 := &resource{container: container.InspectResponse{ID: "dup-1"}}
+	r2 := &resource{container: container.InspectResponse{ID: "dup-2"}}
 
 	// Register r1: refs=1
-	registerWithScope("scope", "dup-id", r1)
+	register("dup-id", r1)
 	// Register r2 with same key: refs=2 (r1 is canonical)
-	stored, loaded := registerWithScope("scope", "dup-id", r2)
+	stored, loaded := register("dup-id", r2)
 	if !loaded {
 		t.Fatal("second register loaded = false, want true")
 	}
@@ -277,58 +243,58 @@ func TestRegistryRefCountingRegisterIncrementsOnDuplicate(t *testing.T) {
 	}
 
 	// Need 2 releases to remove
-	if releaseWithScope("scope", "dup-id") {
+	if release("dup-id") {
 		t.Fatal("first release was last, want false")
 	}
-	if !releaseWithScope("scope", "dup-id") {
+	if !release("dup-id") {
 		t.Fatal("second release was not last, want true")
 	}
 }
 
-func TestAcquireWithScopeNonExistent(t *testing.T) {
+func TestAcquireNonExistent(t *testing.T) {
 	ResetRegistry()
 
-	_, ok := acquireWithScope("scope", "nonexistent")
+	_, ok := acquire("nonexistent")
 	if ok {
-		t.Fatal("acquireWithScope returned true for nonexistent entry, want false")
+		t.Fatal("acquire returned true for nonexistent entry, want false")
 	}
 }
 
-func TestReleaseWithScopeNonExistent(t *testing.T) {
+func TestReleaseNonExistent(t *testing.T) {
 	ResetRegistry()
 
 	// Releasing a nonexistent entry should return true (treat as last reference)
-	if !releaseWithScope("scope", "nonexistent") {
-		t.Fatal("releaseWithScope returned false for nonexistent entry, want true")
+	if !release("nonexistent") {
+		t.Fatal("release returned false for nonexistent entry, want true")
 	}
 }
 
-func TestGetWithScopeDoesNotIncrementRefs(t *testing.T) {
+func TestGetDoesNotIncrementRefs(t *testing.T) {
 	ResetRegistry()
 
-	r := &Resource{Container: container.InspectResponse{ID: "get-no-inc"}}
+	r := &resource{container: container.InspectResponse{ID: "get-no-inc"}}
 
 	// Register: refs=1
-	registerWithScope("s", "id", r)
+	register("id", r)
 
-	// getWithScope five times — should NOT increment refs
+	// get five times — should NOT increment refs
 	for range 5 {
-		got, ok := getWithScope("s", "id")
+		got, ok := get("id")
 		if !ok {
-			t.Fatal("getWithScope returned false, want true")
+			t.Fatal("get returned false, want true")
 		}
 		if got.ID() != r.ID() {
-			t.Fatalf("getWithScope returned %q, want %q", got.ID(), r.ID())
+			t.Fatalf("get returned %q, want %q", got.ID(), r.ID())
 		}
 	}
 
 	// Single release should be the last ref (still 1)
-	if !releaseWithScope("s", "id") {
-		t.Fatal("releaseWithScope returned false, want true (last ref)")
+	if !release("id") {
+		t.Fatal("release returned false, want true (last ref)")
 	}
 
 	// Entry should be gone
-	if _, ok := getWithScope("s", "id"); ok {
+	if _, ok := get("id"); ok {
 		t.Fatal("entry still present after last release, want it removed")
 	}
 }

--- a/resource.go
+++ b/resource.go
@@ -11,22 +11,47 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/moby/moby/api/pkg/stdcopy"
-	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/types/container"
+	mobynetwork "github.com/moby/moby/api/types/network"
 	mobyclient "github.com/moby/moby/client"
 )
 
+// Resource provides access to a Docker container.
+// Returned by *T variants; does not expose Close, CloseT, or Cleanup.
+type Resource interface {
+	ID() string
+	Container() container.InspectResponse
+	GetPort(portID string) string
+	GetBoundIP(portID string) string
+	GetHostPort(portID string) string
+	Logs(ctx context.Context) (string, error)
+	Exec(ctx context.Context, cmd []string) (ExecResult, error)
+	ConnectToNetwork(ctx context.Context, net Network) error
+	DisconnectFromNetwork(ctx context.Context, net Network) error
+	GetIPInNetwork(net Network) string
+}
+
+// ClosableResource extends Resource with explicit lifecycle management.
+// Returned by Run and BuildAndRun; the caller is responsible for calling Close.
+type ClosableResource interface {
+	Resource
+	Close(ctx context.Context) error
+	CloseT(t TestingTB)
+	Cleanup(t TestingTB)
+}
+
 // GetPort returns the host port bound to the given container port.
 // The portID parameter should include the protocol (e.g., "5432/tcp").
-func (r *Resource) GetPort(portID string) string {
-	if r.Container.NetworkSettings == nil {
+func (r *resource) GetPort(portID string) string {
+	if r.container.NetworkSettings == nil {
 		return ""
 	}
 
-	port, err := network.ParsePort(portID)
+	port, err := mobynetwork.ParsePort(portID)
 	if err != nil {
 		return ""
 	}
-	bindings := r.Container.NetworkSettings.Ports[port]
+	bindings := r.container.NetworkSettings.Ports[port]
 	if len(bindings) == 0 {
 		return ""
 	}
@@ -36,16 +61,16 @@ func (r *Resource) GetPort(portID string) string {
 
 // GetBoundIP returns the host IP bound to the given container port.
 // The portID parameter should include the protocol (e.g., "5432/tcp").
-func (r *Resource) GetBoundIP(portID string) string {
-	if r.Container.NetworkSettings == nil {
+func (r *resource) GetBoundIP(portID string) string {
+	if r.container.NetworkSettings == nil {
 		return ""
 	}
 
-	port, err := network.ParsePort(portID)
+	port, err := mobynetwork.ParsePort(portID)
 	if err != nil {
 		return ""
 	}
-	bindings := r.Container.NetworkSettings.Ports[port]
+	bindings := r.container.NetworkSettings.Ports[port]
 	if len(bindings) == 0 {
 		return ""
 	}
@@ -60,7 +85,7 @@ func (r *Resource) GetBoundIP(portID string) string {
 
 // GetHostPort returns the host:port combination for the given container port.
 // The portID parameter should include the protocol (e.g., "5432/tcp").
-func (r *Resource) GetHostPort(portID string) string {
+func (r *resource) GetHostPort(portID string) string {
 	ip := r.GetBoundIP(portID)
 	port := r.GetPort(portID)
 
@@ -77,24 +102,26 @@ func (r *Resource) GetHostPort(portID string) string {
 // For reused containers (those with a reuseID), Close only removes the Docker
 // container when the last reference is released. If other callers still hold
 // references, Close simply untracks the resource from this pool.
-func (r *Resource) Close(ctx context.Context) error {
+func (r *resource) Close(ctx context.Context) error {
 	if r.pool == nil || r.pool.client == nil {
 		return ErrClientClosed
 	}
 
 	if r.reuseID != "" {
-		if !releaseWithScope(r.pool.reuseScope, r.reuseID) {
+		registryKey := r.pool.registryKey(r.reuseID)
+		r.reuseID = "" // prevent double-release on repeated Close calls
+		if !release(registryKey) {
 			// Other callers still hold references; just untrack from this pool.
-			r.pool.untrackResource(r.Container.ID)
+			r.pool.untrackResource(r.container.ID)
 			return nil
 		}
 	}
 
 	// Stop container (ignore errors if already stopped)
-	_, _ = r.pool.client.ContainerStop(ctx, r.Container.ID, mobyclient.ContainerStopOptions{}) //nolint:errcheck // Best effort stop
+	_, _ = r.pool.client.ContainerStop(ctx, r.container.ID, mobyclient.ContainerStopOptions{}) //nolint:errcheck // Best effort stop
 
 	// Remove container (tolerate already-removed containers)
-	_, err := r.pool.client.ContainerRemove(ctx, r.Container.ID, mobyclient.ContainerRemoveOptions{
+	_, err := r.pool.client.ContainerRemove(ctx, r.container.ID, mobyclient.ContainerRemoveOptions{
 		RemoveVolumes: true,
 		Force:         true,
 	})
@@ -102,13 +129,13 @@ func (r *Resource) Close(ctx context.Context) error {
 		return err
 	}
 
-	r.pool.untrackResource(r.Container.ID)
+	r.pool.untrackResource(r.container.ID)
 
 	return nil
 }
 
 // CloseT stops and removes the container and calls t.Fatalf on error.
-func (r *Resource) CloseT(t TestingTB) {
+func (r *resource) CloseT(t TestingTB) {
 	t.Helper()
 	if err := r.Close(context.WithoutCancel(t.Context())); err != nil {
 		t.Fatalf("CloseT failed: %v", err)
@@ -117,7 +144,7 @@ func (r *Resource) CloseT(t TestingTB) {
 
 // Cleanup registers container cleanup with t.Cleanup.
 // The container will be removed when the test finishes.
-func (r *Resource) Cleanup(t TestingTB) {
+func (r *resource) Cleanup(t TestingTB) {
 	t.Helper()
 	t.Cleanup(func() {
 		if err := r.Close(context.WithoutCancel(t.Context())); err != nil {
@@ -128,12 +155,12 @@ func (r *Resource) Cleanup(t TestingTB) {
 
 // Logs returns the container logs, demultiplexing stdout and stderr streams.
 // Both stdout and stderr are combined in the returned string.
-func (r *Resource) Logs(ctx context.Context) (string, error) {
+func (r *resource) Logs(ctx context.Context) (string, error) {
 	if r.pool == nil || r.pool.client == nil {
 		return "", ErrClientClosed
 	}
 
-	reader, err := r.pool.client.ContainerLogs(ctx, r.Container.ID, mobyclient.ContainerLogsOptions{
+	reader, err := r.pool.client.ContainerLogs(ctx, r.container.ID, mobyclient.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 	})
@@ -158,12 +185,12 @@ type ExecResult struct {
 }
 
 // Exec runs a command inside the container and returns the result.
-func (r *Resource) Exec(ctx context.Context, cmd []string) (ExecResult, error) {
+func (r *resource) Exec(ctx context.Context, cmd []string) (ExecResult, error) {
 	if r.pool == nil || r.pool.client == nil {
 		return ExecResult{}, ErrClientClosed
 	}
 
-	createResp, err := r.pool.client.ExecCreate(ctx, r.Container.ID, mobyclient.ExecCreateOptions{
+	createResp, err := r.pool.client.ExecCreate(ctx, r.container.ID, mobyclient.ExecCreateOptions{
 		Cmd:          cmd,
 		AttachStdout: true,
 		AttachStderr: true,
@@ -193,4 +220,78 @@ func (r *Resource) Exec(ctx context.Context, cmd []string) (ExecResult, error) {
 		StdErr:   stderr.String(),
 		ExitCode: inspectResp.ExitCode,
 	}, nil
+}
+
+// ConnectToNetwork connects the container to the given network.
+// The resource's container field is automatically updated with the latest
+// network settings after connection.
+func (r *resource) ConnectToNetwork(ctx context.Context, net Network) error {
+	if r.pool == nil || r.pool.client == nil {
+		return ErrClientClosed
+	}
+
+	connectOpts := mobyclient.NetworkConnectOptions{
+		Container: r.container.ID,
+	}
+
+	_, err := r.pool.client.NetworkConnect(ctx, net.ID(), connectOpts)
+	if err != nil {
+		return err
+	}
+
+	// Refresh container inspection to get updated network settings
+	inspectResp, err := r.pool.client.ContainerInspect(ctx, r.container.ID, mobyclient.ContainerInspectOptions{})
+	if err != nil {
+		return err
+	}
+
+	r.container = inspectResp.Container
+	return nil
+}
+
+// DisconnectFromNetwork disconnects the container from the given network.
+// The resource's container field is automatically updated with the latest
+// network settings after disconnection.
+func (r *resource) DisconnectFromNetwork(ctx context.Context, net Network) error {
+	if r.pool == nil || r.pool.client == nil {
+		return ErrClientClosed
+	}
+
+	disconnectOpts := mobyclient.NetworkDisconnectOptions{
+		Container: r.container.ID,
+		Force:     false,
+	}
+
+	_, err := r.pool.client.NetworkDisconnect(ctx, net.ID(), disconnectOpts)
+	if err != nil {
+		return err
+	}
+
+	// Refresh container inspection to get updated network settings
+	inspectResp, err := r.pool.client.ContainerInspect(ctx, r.container.ID, mobyclient.ContainerInspectOptions{})
+	if err != nil {
+		return err
+	}
+
+	r.container = inspectResp.Container
+	return nil
+}
+
+// GetIPInNetwork returns the container's IP address in the given network.
+// Returns empty string if the container is not connected to the network.
+func (r *resource) GetIPInNetwork(net Network) string {
+	if r.container.NetworkSettings == nil {
+		return ""
+	}
+
+	if r.container.NetworkSettings.Networks == nil {
+		return ""
+	}
+
+	endpoint, ok := r.container.NetworkSettings.Networks[net.Inspect().Name]
+	if !ok {
+		return ""
+	}
+
+	return endpoint.IPAddress.String()
 }

--- a/resource_test.go
+++ b/resource_test.go
@@ -13,16 +13,14 @@ import (
 )
 
 func TestResourceGetPort(t *testing.T) {
-	r := &dockertest.Resource{
-		Container: container.InspectResponse{
-			ID: "test123",
-			NetworkSettings: &container.NetworkSettings{
-				Ports: network.PortMap{
-					network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "54320"}},
-				},
+	r := dockertest.NewResource(container.InspectResponse{
+		ID: "test123",
+		NetworkSettings: &container.NetworkSettings{
+			Ports: network.PortMap{
+				network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "54320"}},
 			},
 		},
-	}
+	})
 
 	port := r.GetPort("5432/tcp")
 	if port != "54320" {
@@ -36,11 +34,9 @@ func TestResourceGetPort(t *testing.T) {
 	}
 
 	// Test nil NetworkSettings
-	rNil := &dockertest.Resource{
-		Container: container.InspectResponse{
-			ID: "test456",
-		},
-	}
+	rNil := dockertest.NewResource(container.InspectResponse{
+		ID: "test456",
+	})
 	port = rNil.GetPort("5432/tcp")
 	if port != "" {
 		t.Errorf("GetPort(nil NetworkSettings) = %q, want empty string", port)
@@ -48,15 +44,13 @@ func TestResourceGetPort(t *testing.T) {
 }
 
 func TestResourceGetBoundIP(t *testing.T) {
-	r := &dockertest.Resource{
-		Container: container.InspectResponse{
-			NetworkSettings: &container.NetworkSettings{
-				Ports: network.PortMap{
-					network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("192.168.1.100"), HostPort: "54320"}},
-				},
+	r := dockertest.NewResource(container.InspectResponse{
+		NetworkSettings: &container.NetworkSettings{
+			Ports: network.PortMap{
+				network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("192.168.1.100"), HostPort: "54320"}},
 			},
 		},
-	}
+	})
 
 	ip := r.GetBoundIP("5432/tcp")
 	if ip != "192.168.1.100" {
@@ -70,9 +64,7 @@ func TestResourceGetBoundIP(t *testing.T) {
 	}
 
 	// Test nil NetworkSettings
-	rNil := &dockertest.Resource{
-		Container: container.InspectResponse{},
-	}
+	rNil := dockertest.NewResource(container.InspectResponse{})
 	ip = rNil.GetBoundIP("5432/tcp")
 	if ip != "" {
 		t.Errorf("GetBoundIP(nil NetworkSettings) = %q, want empty string", ip)
@@ -80,15 +72,13 @@ func TestResourceGetBoundIP(t *testing.T) {
 }
 
 func TestResourceGetBoundIPLocalhostFallback(t *testing.T) {
-	r := &dockertest.Resource{
-		Container: container.InspectResponse{
-			NetworkSettings: &container.NetworkSettings{
-				Ports: network.PortMap{
-					network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: "54320"}},
-				},
+	r := dockertest.NewResource(container.InspectResponse{
+		NetworkSettings: &container.NetworkSettings{
+			Ports: network.PortMap{
+				network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: "54320"}},
 			},
 		},
-	}
+	})
 
 	ip := r.GetBoundIP("5432/tcp")
 	if ip != "127.0.0.1" {
@@ -97,15 +87,13 @@ func TestResourceGetBoundIPLocalhostFallback(t *testing.T) {
 }
 
 func TestResourceGetHostPort(t *testing.T) {
-	r := &dockertest.Resource{
-		Container: container.InspectResponse{
-			NetworkSettings: &container.NetworkSettings{
-				Ports: network.PortMap{
-					network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "54320"}},
-				},
+	r := dockertest.NewResource(container.InspectResponse{
+		NetworkSettings: &container.NetworkSettings{
+			Ports: network.PortMap{
+				network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "54320"}},
 			},
 		},
-	}
+	})
 
 	hostPort := r.GetHostPort("5432/tcp")
 	if hostPort != "127.0.0.1:54320" {
@@ -119,9 +107,7 @@ func TestResourceGetHostPort(t *testing.T) {
 	}
 
 	// Test nil NetworkSettings
-	rNil := &dockertest.Resource{
-		Container: container.InspectResponse{},
-	}
+	rNil := dockertest.NewResource(container.InspectResponse{})
 	hostPort = rNil.GetHostPort("5432/tcp")
 	if hostPort != "" {
 		t.Errorf("GetHostPort(nil NetworkSettings) = %q, want empty string", hostPort)
@@ -129,15 +115,13 @@ func TestResourceGetHostPort(t *testing.T) {
 }
 
 func TestResourceGetHostPortIPv6(t *testing.T) {
-	r := &dockertest.Resource{
-		Container: container.InspectResponse{
-			NetworkSettings: &container.NetworkSettings{
-				Ports: network.PortMap{
-					network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("::1"), HostPort: "54320"}},
-				},
+	r := dockertest.NewResource(container.InspectResponse{
+		NetworkSettings: &container.NetworkSettings{
+			Ports: network.PortMap{
+				network.MustParsePort("5432/tcp"): []network.PortBinding{{HostIP: netip.MustParseAddr("::1"), HostPort: "54320"}},
 			},
 		},
-	}
+	})
 
 	hostPort := r.GetHostPort("5432/tcp")
 	if hostPort != "[::1]:54320" {

--- a/retry.go
+++ b/retry.go
@@ -57,10 +57,10 @@ func RetryWithBackoff(ctx context.Context, timeout, initialInterval, maxInterval
 }
 
 // Retry is a convenience method that wraps the package-level Retry function.
-// If timeout is 0, Pool.MaxWait is used as the default. The interval is fixed at 1 second.
-func (p *Pool) Retry(ctx context.Context, timeout time.Duration, fn func() error) error {
+// If timeout is 0, pool.maxWait is used as the default. The interval is fixed at 1 second.
+func (p *pool) Retry(ctx context.Context, timeout time.Duration, fn func() error) error {
 	if timeout == 0 {
-		timeout = p.MaxWait
+		timeout = p.maxWait
 	}
 	return Retry(ctx, timeout, 1*time.Second, fn)
 }

--- a/run_test.go
+++ b/run_test.go
@@ -33,9 +33,6 @@ func TestPoolRun(t *testing.T) {
 	if r.ID() == "" {
 		t.Fatal("Resource has empty container ID")
 	}
-
-	// Cleanup
-	r.CloseT(t)
 }
 
 func TestPoolRunWithReuse(t *testing.T) {
@@ -65,8 +62,6 @@ func TestPoolRunWithReuse(t *testing.T) {
 	if r1.ID() != r2.ID() {
 		t.Errorf("Reuse failed: got different containers %s != %s", r1.ID(), r2.ID())
 	}
-
-	r1.CloseT(t)
 }
 
 func TestPoolRunWithoutReuse(t *testing.T) {
@@ -98,9 +93,6 @@ func TestPoolRunWithoutReuse(t *testing.T) {
 	if r1.ID() == r2.ID() {
 		t.Errorf("WithoutReuse failed: got same container %s", r1.ID())
 	}
-
-	r1.CloseT(t)
-	r2.CloseT(t)
 }
 
 func TestPoolRunWithReuseID(t *testing.T) {
@@ -132,8 +124,6 @@ func TestPoolRunWithReuseID(t *testing.T) {
 	if r1.ID() != r2.ID() {
 		t.Errorf("WithReuseID failed to reuse: got different containers %s != %s", r1.ID(), r2.ID())
 	}
-
-	r1.CloseT(t)
 }
 
 func TestPoolRunWithDifferentReuseIDs(t *testing.T) {
@@ -165,9 +155,6 @@ func TestPoolRunWithDifferentReuseIDs(t *testing.T) {
 	if r1.ID() == r2.ID() {
 		t.Errorf("Different WithReuseID should create different containers, got same: %s", r1.ID())
 	}
-
-	r1.CloseT(t)
-	r2.CloseT(t)
 }
 
 func TestPoolRunWithReuseIDIgnoresTag(t *testing.T) {
@@ -199,8 +186,6 @@ func TestPoolRunWithReuseIDIgnoresTag(t *testing.T) {
 	if r1.ID() != r2.ID() {
 		t.Errorf("WithReuseID should override tag-based reuse: got different containers %s != %s", r1.ID(), r2.ID())
 	}
-
-	r1.CloseT(t)
 }
 
 func TestRunWithUser(t *testing.T) {
@@ -221,13 +206,10 @@ func TestRunWithUser(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "10"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
 	// Verify the user was set in container config
-	if resource.Container.Config.User != "nobody" {
-		t.Errorf("expected user 'nobody', got %q", resource.Container.Config.User)
+	if resource.Container().Config.User != "nobody" {
+		t.Errorf("expected user 'nobody', got %q", resource.Container().Config.User)
 	}
 }
 
@@ -249,12 +231,9 @@ func TestRunWithWorkingDir(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "10"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
-	if resource.Container.Config.WorkingDir != "/tmp" {
-		t.Errorf("expected working dir '/tmp', got %q", resource.Container.Config.WorkingDir)
+	if resource.Container().Config.WorkingDir != "/tmp" {
+		t.Errorf("expected working dir '/tmp', got %q", resource.Container().Config.WorkingDir)
 	}
 }
 
@@ -282,20 +261,17 @@ func TestRunWithLabelsAndHostname(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "10"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
 	// Verify labels
 	for k, v := range labels {
-		if resource.Container.Config.Labels[k] != v {
-			t.Errorf("expected label %s=%s, got %s", k, v, resource.Container.Config.Labels[k])
+		if resource.Container().Config.Labels[k] != v {
+			t.Errorf("expected label %s=%s, got %s", k, v, resource.Container().Config.Labels[k])
 		}
 	}
 
 	// Verify hostname
-	if resource.Container.Config.Hostname != "test-host" {
-		t.Errorf("expected hostname 'test-host', got %q", resource.Container.Config.Hostname)
+	if resource.Container().Config.Hostname != "test-host" {
+		t.Errorf("expected hostname 'test-host', got %q", resource.Container().Config.Hostname)
 	}
 }
 
@@ -322,16 +298,13 @@ func TestRunWithContainerConfig(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "10"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
-	if resource.Container.Config.StopTimeout == nil || *resource.Container.Config.StopTimeout != 5 {
-		t.Errorf("expected stop timeout 5, got %v", resource.Container.Config.StopTimeout)
+	if resource.Container().Config.StopTimeout == nil || *resource.Container().Config.StopTimeout != 5 {
+		t.Errorf("expected stop timeout 5, got %v", resource.Container().Config.StopTimeout)
 	}
 
-	if resource.Container.Config.StopSignal != "SIGTERM" {
-		t.Errorf("expected stop signal 'SIGTERM', got %q", resource.Container.Config.StopSignal)
+	if resource.Container().Config.StopSignal != "SIGTERM" {
+		t.Errorf("expected stop signal 'SIGTERM', got %q", resource.Container().Config.StopSignal)
 	}
 }
 
@@ -355,15 +328,12 @@ func TestRunWithHostConfig(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "10"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
-	if resource.Container.HostConfig.RestartPolicy.Name != container.RestartPolicyOnFailure {
-		t.Errorf("expected restart policy %q, got %q", container.RestartPolicyOnFailure, resource.Container.HostConfig.RestartPolicy.Name)
+	if resource.Container().HostConfig.RestartPolicy.Name != container.RestartPolicyOnFailure {
+		t.Errorf("expected restart policy %q, got %q", container.RestartPolicyOnFailure, resource.Container().HostConfig.RestartPolicy.Name)
 	}
-	if resource.Container.HostConfig.RestartPolicy.MaximumRetryCount != 3 {
-		t.Errorf("expected max retry count 3, got %d", resource.Container.HostConfig.RestartPolicy.MaximumRetryCount)
+	if resource.Container().HostConfig.RestartPolicy.MaximumRetryCount != 3 {
+		t.Errorf("expected max retry count 3, got %d", resource.Container().HostConfig.RestartPolicy.MaximumRetryCount)
 	}
 }
 
@@ -384,9 +354,6 @@ func TestResourceExec(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "300"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
 	result, err := resource.Exec(t.Context(), []string{"echo", "hello world"})
 	if err != nil {
@@ -421,9 +388,6 @@ func TestResourceExecNonZeroExit(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "300"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
 	result, err := resource.Exec(t.Context(), []string{"sh", "-c", "echo err >&2; exit 1"})
 	if err != nil {
@@ -457,12 +421,9 @@ func TestRunWithName(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "10"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
-	if resource.Container.Name != "/"+containerName && resource.Container.Name != containerName {
-		t.Errorf("expected container name containing %q, got %q", containerName, resource.Container.Name)
+	if resource.Container().Name != "/"+containerName && resource.Container().Name != containerName {
+		t.Errorf("expected container name containing %q, got %q", containerName, resource.Container().Name)
 	}
 }
 
@@ -495,15 +456,12 @@ func TestRunWithPortBindings(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "10"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
-	if len(resource.Container.HostConfig.PortBindings[port]) == 0 {
+	if len(resource.Container().HostConfig.PortBindings[port]) == 0 {
 		t.Fatalf("expected port binding for %s, got none", port)
 	}
-	if resource.Container.HostConfig.PortBindings[port][0].HostPort != "18080" {
-		t.Errorf("expected host port 18080, got %q", resource.Container.HostConfig.PortBindings[port][0].HostPort)
+	if resource.Container().HostConfig.PortBindings[port][0].HostPort != "18080" {
+		t.Errorf("expected host port 18080, got %q", resource.Container().HostConfig.PortBindings[port][0].HostPort)
 	}
 }
 
@@ -519,17 +477,24 @@ func TestResourceCloseRefCounting(t *testing.T) {
 
 	pool := dockertest.NewPoolT(t, "")
 
+	// Use Run (not RunT) to get raw *Resource for manual lifecycle management
 	// First run creates the container: refs=1
-	r1 := pool.RunT(t, "alpine",
+	r1, err := pool.Run(t.Context(), "alpine",
 		dockertest.WithTag("latest"),
 		dockertest.WithCmd([]string{"sleep", "300"}),
 	)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
 
 	// Second run reuses the same container: refs=2
-	r2 := pool.RunT(t, "alpine",
+	r2, err := pool.Run(t.Context(), "alpine",
 		dockertest.WithTag("latest"),
 		dockertest.WithCmd([]string{"sleep", "300"}),
 	)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
 
 	if r1.ID() != r2.ID() {
 		t.Fatalf("expected same container ID for reused container, got %s and %s", r1.ID(), r2.ID())
@@ -584,18 +549,52 @@ func TestRunWithMounts(t *testing.T) {
 		dockertest.WithCmd([]string{"sleep", "10"}),
 		dockertest.WithoutReuse(),
 	)
-	t.Cleanup(func() {
-		resource.CloseT(t)
-	})
 
 	found := false
-	for _, bind := range resource.Container.HostConfig.Binds {
+	for _, bind := range resource.Container().HostConfig.Binds {
 		if bind == "/tmp:/mnt/test:ro" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected bind mount /tmp:/mnt/test:ro in %v", resource.Container.HostConfig.Binds)
+		t.Errorf("expected bind mount /tmp:/mnt/test:ro in %v", resource.Container().HostConfig.Binds)
+	}
+}
+
+func TestRunTAutoCleanup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	dc, err := mobyclient.New(mobyclient.FromEnv)
+	if err != nil {
+		t.Fatalf("mobyclient.New() error = %v", err)
+	}
+	t.Cleanup(func() { dc.Close() })
+
+	var containerID string
+
+	t.Run("sub-test", func(t *testing.T) {
+		pool := dockertest.NewPoolT(t, "")
+
+		r := pool.RunT(t, "alpine",
+			dockertest.WithTag("latest"),
+			dockertest.WithCmd([]string{"sleep", "300"}),
+			dockertest.WithoutReuse(),
+		)
+
+		containerID = r.ID()
+	})
+
+	// After sub-test completes, t.Cleanup should have removed the container
+	_, err = dc.ContainerInspect(t.Context(), containerID, mobyclient.ContainerInspectOptions{})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("ContainerInspect() after sub-test: error = %v, want not found (auto-cleanup should have removed it)", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace `ManagedResource`, `ManagedPool`, `ManagedNetwork` wrapper structs with Go interfaces — removes ~115 lines of manual delegation boilerplate
- `*T` variants return the restricted interface (`Resource`, `Pool`, `Network`); non-T variants return the closable interface (`ClosableResource`, `ClosablePool`, `ClosableNetwork`), providing the same compile-time safety with less code
- Unexport `Pool` struct → `pool`, `Network` struct → `dockerNetwork`; public API is now entirely interface-based
- `ConnectToNetwork` / `DisconnectFromNetwork` / `GetIPInNetwork` accept the `Network` interface directly — eliminates the `ManagedNetwork.Network()` escape hatch
- Add `NewResource(container.InspectResponse) ClosableResource` constructor for external unit tests
- Convert `examples/cleanup/main.go` to `TestExplicitCleanup`, demonstrating explicit lifecycle management without T helpers

## Test plan

- [ ] `go build ./...` — all files compile
- [ ] `go vet ./...` — no vet issues
- [ ] Unit tests (no Docker): `go test -short ./...`
- [ ] Integration tests: `go test ./...`
- [ ] Examples module: `cd examples && go build ./...`
- [ ] Verify `RunT` returns `Resource` (no `Close` method visible)
- [ ] Verify `Run` returns `ClosableResource` (has `Close`)
- [ ] Verify `NewPoolT` returns `Pool` (no `Close`)
- [ ] Verify `NewPool` returns `ClosablePool` (has `Close`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)