### PR TITLE
build: restore BuildOptions.Version for selecting the builder

### DIFF
--- a/build.go
+++ b/build.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 
 	"github.com/distribution/reference"
+	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/jsonstream"
 	mobyclient "github.com/moby/moby/client"
 )
@@ -54,6 +55,10 @@ type BuildOptions struct {
 	// ForceRemove always removes intermediate containers, even on build failure.
 	// Useful for keeping the build environment clean.
 	ForceRemove bool
+
+	// Version specifies the builder to use. "1" for classic, "2" for BuildKit.
+	// Defaults to the daemon's configured default if empty.
+	Version string
 }
 
 // BuildAndRun builds a Docker image from a Dockerfile and runs it as a container.
@@ -111,6 +116,7 @@ func (p *pool) BuildAndRun(ctx context.Context, name string, buildOpts *BuildOpt
 		Remove:      true,
 		ForceRemove: buildOpts.ForceRemove,
 		Labels:      buildOpts.Labels,
+		Version:     build.BuilderVersion(buildOpts.Version),
 	}
 
 	buildResult, err := p.client.ImageBuild(ctx, buildContext, imageBuildOpts)

--- a/build_test.go
+++ b/build_test.go
@@ -243,6 +243,39 @@ CMD ["sleep", "300"]
 	}
 }
 
+func TestBuildAndRunWithBuildKit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	dockertest.ResetRegistry()
+	t.Cleanup(func() {
+		dockertest.ResetRegistry()
+	})
+
+	pool := dockertest.NewPoolT(t, "")
+	tmpDir := t.TempDir()
+
+	dockerfile := `FROM alpine:latest
+CMD ["sleep", "300"]
+`
+	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
+	if err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o644); err != nil {
+		t.Fatalf("Failed to write Dockerfile: %v", err)
+	}
+
+	buildOpts := &dockertest.BuildOptions{
+		Dockerfile: "Dockerfile",
+		ContextDir: tmpDir,
+		Version:    "2", // BuildKit
+	}
+
+	r := pool.BuildAndRunT(t, "test-build-buildkit", buildOpts)
+	if r == nil {
+		t.Fatal("BuildAndRunT returned nil resource")
+	}
+}
+
 func TestRunUsesLocalImageWithoutPull(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
This PR was written primarily by Claude Code; I reviewed the change and ran the build test suite against a local Docker daemon before submitting.

## Problem

v3's `BuildOptions` had a `Version` field controlling which builder the daemon uses ("1" for classic, "2" for BuildKit, added in #416). That field is missing from v4's `BuildOptions`, even though the underlying `mobyclient.ImageBuildOptions` (used internally) already has an equivalent `Version build.BuilderVersion` field. The v4 rewrite (#631) just never carried it over.

## Fix

- Added `Version string` back to `BuildOptions` (`build.go`), matching v3's field name, type, and doc comment.
- Passed it through as `build.BuilderVersion(buildOpts.Version)` to `imageBuildOpts.Version`.

## Testing

- Added `TestBuildAndRunWithBuildKit`, which builds and runs an image with `Version: "2"` set, following the same pattern as the existing `TestBuildAndRun*` tests.
- Ran the full `TestBuild*` suite against a local Docker daemon: all 6 tests pass, including the new one.
- `go build ./...`, `go vet ./...` clean.

Fixes #663